### PR TITLE
Makefile and test script for ci-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+#This makefile is used by ci-operator
+
+.PHONY: test-e2e
+test-e2e:
+	sh test/e2e-tests-openshift.sh

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ init:
 	@mkdir -p $(BUILD_DIR)/bin
 	@cd $(BUILD_DIR) && \
 	curl -LO $(GCLOUD_URL) && tar xzf $(GCLOUD_ARCHIVE) && \
-	gcloud -q auth configure-docker
+	google-cloud-sdk/bin/gcloud -q auth configure-docker
 	@echo "Downloading kubectl"
 	@cd $(BUILD_DIR)/bin && \
 	curl -LO $(KUBECTL_URL) && chmod +x ./kubectl

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,28 @@
 #This makefile is used by ci-operator
 
+BUILD_DIR=$(shell pwd)/build
+GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-222.0.0-linux-x86_64.tar.gz
+GCLOUD_ARCHIVE=$(shell echo $(GCLOUD_URL) | rev | cut -d/ -f1 | rev)
+KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
+
+#TODO: Move this to a builder image in CI
+.PHONY: init
+init:
+	@echo "Downloading gcloud"
+	@mkdir -p $(BUILD_DIR)/bin
+	@cd $(BUILD_DIR) && \
+	curl -LO --progress-bar $(GCLOUD_URL) && tar xzf $(GCLOUD_ARCHIVE)
+	@echo "Downloading kubectl"
+	@cd $(BUILD_DIR)/bin && \
+	curl -LO --progress-bar $(KUBECTL_URL) && chmod +x ./kubectl
+	@echo "Downloading ko"
+	go get github.com/google/go-containerregistry/cmd/ko
+	@echo "Done preparing environment"
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR)
+
 .PHONY: test-e2e
-test-e2e:
+test-e2e: init
 	sh test/e2e-tests-openshift.sh

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ BUILD_DIR=$(shell pwd)/build
 GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-222.0.0-linux-x86_64.tar.gz
 GCLOUD_ARCHIVE=$(shell echo $(GCLOUD_URL) | rev | cut -d/ -f1 | rev)
 KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
-CI_SERVICE_ACCOUNT=aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com
-CI_PROJECT=openshift-gce-devel-ci
 
 #TODO: Move this to a builder image in CI
 .PHONY: init
@@ -14,8 +12,6 @@ init:
 	@mkdir -p $(BUILD_DIR)/bin
 	@cd $(BUILD_DIR) && \
 	curl -LO $(GCLOUD_URL) && tar xzf $(GCLOUD_ARCHIVE) && \
-	google-cloud-sdk/bin/gcloud auth activate-service-account $(CI_SERVICE_ACCOUNT) \
-	--key-file=$(GOOGLE_APPLICATION_CREDENTIALS) --project=$(CI_PROJECT) && \
 	gcloud -q auth configure-docker
 	@echo "Downloading kubectl"
 	@cd $(BUILD_DIR)/bin && \

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,22 @@ BUILD_DIR=$(shell pwd)/build
 GCLOUD_URL=https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-222.0.0-linux-x86_64.tar.gz
 GCLOUD_ARCHIVE=$(shell echo $(GCLOUD_URL) | rev | cut -d/ -f1 | rev)
 KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
+CI_SERVICE_ACCOUNT=aos-serviceaccount@openshift-gce-devel.iam.gserviceaccount.com
+CI_PROJECT=openshift-gce-devel-ci
 
 #TODO: Move this to a builder image in CI
 .PHONY: init
 init:
-	@echo "Downloading gcloud"
+	@echo "Downloading gcloud and authenticate"
 	@mkdir -p $(BUILD_DIR)/bin
 	@cd $(BUILD_DIR) && \
-	curl -LO --progress-bar $(GCLOUD_URL) && tar xzf $(GCLOUD_ARCHIVE)
+	curl -LO $(GCLOUD_URL) && tar xzf $(GCLOUD_ARCHIVE) && \
+	google-cloud-sdk/bin/gcloud auth activate-service-account $(CI_SERVICE_ACCOUNT) \
+	--key-file=$(GOOGLE_APPLICATION_CREDENTIALS) --project=$(CI_PROJECT) && \
+	gcloud -q auth configure-docker
 	@echo "Downloading kubectl"
 	@cd $(BUILD_DIR)/bin && \
-	curl -LO --progress-bar $(KUBECTL_URL) && chmod +x ./kubectl
+	curl -LO $(KUBECTL_URL) && chmod +x ./kubectl
 	@echo "Downloading ko"
 	go get github.com/google/go-containerregistry/cmd/ko
 	@echo "Done preparing environment"

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,5 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 .PHONY: test-e2e
-test-e2e: init
-	sh test/e2e-tests-openshift.sh
+test-e2e:
+	sh openshift/e2e-tests-openshift.sh

--- a/openshift/admission-webhooks.yaml
+++ b/openshift/admission-webhooks.yaml
@@ -1,0 +1,38 @@
+---
+- hosts: all
+  become: yes
+  become_user: root
+  tasks:
+    - name: Backup master-config.yaml to master-config.yaml.prepatch
+      copy:
+        src: /etc/origin/master/master-config.yaml
+        dest: /etc/origin/master/master-config.yaml.prepatch
+        remote_src: yes
+        backup: yes
+    - name: Set master_patch variable
+      set_fact:
+        master_patch: |
+          admissionConfig:
+            pluginConfig:
+              MutatingAdmissionWebhook:
+                configuration:
+                  apiVersion: apiserver.config.k8s.io/v1alpha1
+                  kubeConfigFile: /dev/null
+                  kind: WebhookAdmission
+              ValidatingAdmissionWebhook:
+                configuration:
+                  apiVersion: apiserver.config.k8s.io/v1alpha1
+                  kubeConfigFile: /dev/null
+                  kind: WebhookAdmission
+    - name: Apply patch for admission webhooks
+      shell: oc ex config patch /etc/origin/master/master-config.yaml.prepatch -p "{{ master_patch }}" > /etc/origin/master/master-config.yaml
+    - name: Restart API server and constollers
+      shell: /usr/local/bin/master-restart api && /usr/local/bin/master-restart controllers
+    - name: Wait for API server to be available
+      command: oc login -u system:admin
+      register: login_res
+      until: login_res.rc == 0
+      ignore_errors: yes
+      retries: 30
+      delay: 1
+      

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM openshift/origin-release:golang-1.10
+
+# Add Google Cloud SDK repository
+ADD google-cloud-sdk.repo /etc/yum.repos.d/
+
+# Add kubernetes repository
+ADD kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y google-cloud-sdk kubectl ansible && \
+    go get github.com/google/go-containerregistry/cmd/ko

--- a/openshift/ci-operator/build-image/google-cloud-sdk.repo
+++ b/openshift/ci-operator/build-image/google-cloud-sdk.repo
@@ -1,0 +1,9 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/test/e2e-tests-openshift.sh
+++ b/test/e2e-tests-openshift.sh
@@ -1,0 +1,109 @@
+#!/bin/sh 
+
+source $(dirname $0)/cluster.sh
+
+readonly ISTIO_URL='https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml'
+readonly TEST_NAMESPACE=serving-tests
+
+function install_istio(){
+  header "Installing Istio"
+  # Grant the necessary privileges to the service accounts Istio will use:
+  oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z default -n istio-system
+  oc adm policy add-scc-to-user anyuid -z prometheus -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-egressgateway-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-citadel-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-ingressgateway-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-cleanup-old-ca-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
+  oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
+  oc adm policy add-cluster-role-to-user cluster-admin -z istio-galley-service-account -n istio-system
+  
+  # Deploy the latest Istio release
+  oc apply -f $ISTIO_URL
+
+  # Ensure the istio-sidecar-injector pod runs as privileged
+  oc get cm istio-sidecar-injector -n istio-system -o yaml | sed -e 's/securityContext:/securityContext:\\n      privileged: true/' | oc replace -f -
+  # Monitor the Istio components until all the components are up and running
+  wait_until_pods_running istio-system || return 1
+  header "Istio Installed successfully"
+}
+
+function install_knative(){
+  header "Installing Knative"
+  # Grant the necessary privileges to the service accounts Knative will use:
+  oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
+  oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
+  oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
+  oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
+  oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
+
+  # Deploy Knative Serving from the current source repository. This will also install Knative Build.
+  create_serving
+
+  wait_until_pods_running knative-build || return 1
+  wait_until_pods_running knative-serving || return 1
+  wait_until_service_has_external_ip istio-system knative-ingressgateway || fail_test "Ingress has no external IP"
+  header "Knative Installed successfully"
+}
+
+function publish_test_images() {
+  header "Publishing test images"
+  image_dirs="$(find ${REPO_ROOT_DIR}/test/test_images -mindepth 1 -maxdepth 1 -type d)"
+  for image_dir in ${image_dirs}; do
+    ko publish -P "github.com/knative/serving/test/test_images/$(basename ${image_dir})"
+  done
+}
+
+function create_test_namespace(){
+  oc new-project $TEST_NAMESPACE
+}
+
+function run_e2e_tests(){
+  header "Running tests"
+  options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=20m \
+    ./test/conformance ./test/e2e \
+    --kubeconfig $KUBECONFIG \
+    ${options} || fail_test
+  success
+}
+
+function delete_istio(){
+  echo ">> Bringing down Istio"
+  kubectl delete --ignore-not-found=true -f ${ISTIO_URL}
+}
+
+function delete_test_namespace(){
+  echo ">> Deleting test namespace $TEST_NAMESPACE"
+  oc delete project $TEST_NAMESPACE
+}
+
+function teardown() {
+  delete_test_namespace
+  delete_test_resources
+  delete_serving
+  delete_istio
+}
+
+export K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
+export DOCKER_REPO_OVERRIDE=gcr.io/$(gcloud config get-value project)/kserving-e2e-img
+export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
+
+teardown
+
+create_test_namespace
+
+install_istio
+
+install_knative
+
+create_test_resources
+
+publish_test_images
+
+run_e2e_tests

--- a/test/e2e-tests-openshift.sh
+++ b/test/e2e-tests-openshift.sh
@@ -7,6 +7,10 @@ export PATH=$BUILD_DIR/bin:$BUILD_DIR/google-cloud-sdk/bin:$PATH
 export K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
 export DOCKER_REPO_OVERRIDE=gcr.io/$(gcloud config get-value project)/kserving-e2e-img
 export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
+#satisfy e2e_flags.go#initializeFlags()
+export USER=`whoami`
+
+env
 
 readonly ISTIO_URL='https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml'
 readonly TEST_NAMESPACE=serving-tests

--- a/test/e2e-tests-openshift.sh
+++ b/test/e2e-tests-openshift.sh
@@ -96,7 +96,8 @@ function teardown() {
   delete_istio
 }
 
-teardown
+# Delete images in DOCKER_REPO_OVERRIDE repository and call teardown
+teardown_test_resources
 
 create_test_namespace
 

--- a/test/e2e-tests-openshift.sh
+++ b/test/e2e-tests-openshift.sh
@@ -8,7 +8,7 @@ export K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}'
 export DOCKER_REPO_OVERRIDE=gcr.io/$(gcloud config get-value project)/kserving-e2e-img
 export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 #satisfy e2e_flags.go#initializeFlags()
-export USER=`whoami`
+export USER=dev
 
 env
 

--- a/test/e2e-tests-openshift.sh
+++ b/test/e2e-tests-openshift.sh
@@ -2,6 +2,12 @@
 
 source $(dirname $0)/cluster.sh
 
+export BUILD_DIR=`pwd`/build
+export PATH=$BUILD_DIR/bin:$BUILD_DIR/google-cloud-sdk/bin:$PATH
+export K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
+export DOCKER_REPO_OVERRIDE=gcr.io/$(gcloud config get-value project)/kserving-e2e-img
+export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
+
 readonly ISTIO_URL='https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml'
 readonly TEST_NAMESPACE=serving-tests
 
@@ -75,7 +81,7 @@ function run_e2e_tests(){
 
 function delete_istio(){
   echo ">> Bringing down Istio"
-  kubectl delete --ignore-not-found=true -f ${ISTIO_URL}
+  oc delete --ignore-not-found=true -f ${ISTIO_URL}
 }
 
 function delete_test_namespace(){
@@ -89,10 +95,6 @@ function teardown() {
   delete_serving
   delete_istio
 }
-
-export K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
-export DOCKER_REPO_OVERRIDE=gcr.io/$(gcloud config get-value project)/kserving-e2e-img
-export KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 
 teardown
 

--- a/vendor/github.com/knative/pkg/test/e2e_flags.go
+++ b/vendor/github.com/knative/pkg/test/e2e_flags.go
@@ -21,6 +21,7 @@ package test
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/user"
 	"path"
@@ -45,8 +46,12 @@ func initializeFlags() *EnvironmentFlags {
 	flag.StringVar(&f.Cluster, "cluster", defaultCluster,
 		"Provide the cluster to test against. Defaults to $K8S_CLUSTER_OVERRIDE, then current cluster in kubeconfig if $K8S_CLUSTER_OVERRIDE is unset.")
 
-	usr, _ := user.Current()
-	defaultKubeconfig := path.Join(usr.HomeDir, ".kube/config")
+	var defaultKubeconfig string
+	if usr, err := user.Current(); err == nil {
+		defaultKubeconfig = path.Join(usr.HomeDir, ".kube/config")
+	} else {
+		fmt.Printf("Could not get current user: %v", err)
+	}
 
 	flag.StringVar(&f.Kubeconfig, "kubeconfig", defaultKubeconfig,
 		"Provide the path to the `kubeconfig` file you'd like to use for these tests. The `current-context` will be used.")


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This PR adds a Makefile that will be called by ci-operator. The makefile calls a test script specific for openshift.
I tried the scripts on OKD 3.11 running in GCP and the tests passed. There are two specifics related to my test environment:
* Admission webhooks enabled manually by looging in the master node, patching the master config and restarting the API server. This is not possible in CI and right now the admission webhooks are disabled.
* Using a specific GCP project with pre-authenticated gcloud utility. This is required for pushing images to gcr.io. I'm not sure if gcloud is available in CI.

This PR is here to catch any problems with CI except for the admission webhooks.

