### PR TITLE
Modify the image digest expected in revision_test.go

### DIFF
--- a/test/conformance/revision_test.go
+++ b/test/conformance/revision_test.go
@@ -41,7 +41,7 @@ func getImageDigest(clients *test.Clients, names test.ResourceNames) (string, er
 }
 
 func assertIsDigestForImage(t *testing.T, imageName string, imageDigest string) {
-	imageDigestRegex := fmt.Sprintf("%s/%s@sha256:[0-9a-f]{64}", test.ServingFlags.DockerRepo, imageName)
+	imageDigestRegex := fmt.Sprintf("%s@sha256:[0-9a-f]{64}", test.ServingFlags.DockerRepo)
 	match, err := regexp.MatchString(imageDigestRegex, imageDigest)
 	if err != nil {
 		t.Fatalf("Unable to compare regex %s to digest %s", imageDigestRegex, imageDigest)


### PR DESCRIPTION
This is hacky, and just a temporary measure to attempt to get the
remaining CI test green. Longer-term we need a better upstream
solution for resolving test image paths or a fix to the image paths
and tags we're using for CI.
