### PR TITLE
Pull all images from the OpenShift internal registry

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -133,46 +133,7 @@ function resolve_resources(){
 }
 
 function enable_docker_schema2(){
-  cat > config.yaml <<EOF
-  version: 0.1
-  log:
-    level: debug
-  http:
-    addr: :5000
-  storage:
-    cache:
-      blobdescriptor: inmemory
-    filesystem:
-      rootdirectory: /registry
-    delete:
-      enabled: true
-  auth:
-    openshift:
-      realm: openshift
-  middleware:
-    registry:
-      - name: openshift
-    repository:
-      - name: openshift
-        options:
-          acceptschema2: true
-          pullthrough: true
-          enforcequota: false
-          projectcachettl: 1m
-          blobrepositorycachettl: 10m
-    storage:
-      - name: openshift
-  openshift:
-    version: 1.0
-    metrics:
-      enabled: false
-      secret: <secret>
-EOF
-  oc project default
-  oc create configmap registry-config --from-file=./config.yaml
-  oc set volume dc/docker-registry --add --type=configmap --configmap-name=registry-config -m /etc/docker/registry/
-  oc set env dc/docker-registry REGISTRY_CONFIGURATION_PATH=/etc/docker/registry/config.yaml
-  oc project $TEST_NAMESPACE
+  oc set env -n default dc/docker-registry REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ACCEPTSCHEMA2=true
 }
 
 function create_test_namespace(){

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -73,6 +73,10 @@ function install_istio(){
 
 function install_knative(){
   header "Installing Knative"
+
+  # Create knative-serving namespace, needed for imagestreams
+  oc create namespace $SERVING_NAMESPACE
+
   # Grant the necessary privileges to the service accounts Knative will use:
   oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
   oc adm policy add-scc-to-user anyuid -z controller -n knative-serving

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -197,6 +197,10 @@ function tag_test_images() {
     name=$(basename ${image_dir})
     tag_built_image test-${name} ${name}
   done
+
+  # TestContainerErrorMsg also needs an invalidhelloworld imagestream
+  # to exist but NOT have a `latest` tag
+  oc tag -n ${SERVING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:test-helloworld invalidhelloworld:not_latest
 }
 
 function tag_built_image() {

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -116,6 +116,10 @@ function create_test_resources_openshift() {
 
   echo ">> Creating imagestream tags for all test images"
   tag_test_images test/test_images
+
+  echo ">> Ensuring pods in test namespaces can access test images"
+  oc policy add-role-to-group system:image-puller system:serviceaccounts:${TEST_NAMESPACE} --namespace=${SERVING_NAMESPACE}
+  oc policy add-role-to-group system:image-puller system:serviceaccounts:knative-testing --namespace=${SERVING_NAMESPACE}
 }
 
 function resolve_resources(){

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -8,7 +8,7 @@ export BUILD_DIR=`pwd`/../build
 export PATH=$BUILD_DIR/bin:$BUILD_DIR/google-cloud-sdk/bin:$PATH
 export K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
 export API_SERVER=$(oc config view --minify | grep server | awk -F'//' '{print $2}' | awk -F':' '{print $1}')
-export INTERNAL_REGISTRY=$(oc get svc -n default docker-registry -o "jsonpath={.spec.clusterIP}"):$(oc get svc -n default docker-registry -o "jsonpath={.spec.ports[0].port}")
+export INTERNAL_REGISTRY="docker-registry.default.svc:5000"
 export USER=$KUBE_SSH_USER #satisfy e2e_flags.go#initializeFlags()
 export OPENSHIFT_REGISTRY=registry.svc.ci.openshift.org
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -194,7 +194,7 @@ function tag_test_images() {
 function tag_built_image() {
   local remote_name=$1
   local local_name=$2
-  echo "oc tag -n ${SERVING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${remote_name} ${local_name}:latest"
+  oc tag -n ${SERVING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${remote_name} ${local_name}:latest
 }
 
 enable_admission_webhooks

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -78,8 +78,6 @@ func TestHelloWorldFromShell(t *testing.T) {
 	content := strings.Replace(string(yamlBytes), namespacePlaceholder, test.ServingNamespace, -1)
 	content = strings.Replace(string(content), yamlImagePlaceholder, imagePath, -1)
 
-	logger.Infof("New manifest contents are:\n%s", content)
-
 	if _, err = newYaml.WriteString(content); err != nil {
 		t.Fatalf("Failed to write new manifest: %v", err)
 	}
@@ -119,12 +117,6 @@ func TestHelloWorldFromShell(t *testing.T) {
 	outputString := ""
 	timeout = servingTimeout
 	for outputString != helloWorldExpectedOutput && timeout >= 0 {
-		var describeOutput []byte
-		if describeOutput, err = exec.Command("kubectl", "describe", "revision", "-n", test.ServingNamespace).CombinedOutput(); err != nil {
-			t.Fatalf("Error running kubectl: %v", strings.TrimSpace(string(describeOutput)))
-		}
-		logger.Infof("Revisions:\n%s", describeOutput)
-
 		var cmd *exec.Cmd
 		if test.ServingFlags.ResolvableDomain {
 			cmd = exec.Command("curl", serviceHost)

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -75,8 +75,9 @@ func TestHelloWorldFromShell(t *testing.T) {
 		t.Fatalf("Failed to read file %s: %v", appYaml, err)
 	}
 
-	content := strings.Replace(string(yamlBytes), namespacePlaceholder, test.ServingNamespace, -1)
-	content = strings.Replace(string(content), yamlImagePlaceholder, imagePath, -1)
+	content := strings.Replace(string(yamlBytes), yamlImagePlaceholder, imagePath, -1)
+	content = strings.Replace(string(content), "namespace: "+namespacePlaceholder,
+		"namespace: "+test.ServingNamespace, -1)
 
 	if _, err = newYaml.WriteString(content); err != nil {
 		t.Fatalf("Failed to write new manifest: %v", err)

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -78,6 +78,8 @@ func TestHelloWorldFromShell(t *testing.T) {
 	content := strings.Replace(string(yamlBytes), yamlImagePlaceholder, imagePath, -1)
 	content = strings.Replace(string(content), namespacePlaceholder, test.ServingNamespace, -1)
 
+	logger.Infof("New manifest contents are:\n%s", content)
+
 	if _, err = newYaml.WriteString(content); err != nil {
 		t.Fatalf("Failed to write new manifest: %v", err)
 	}
@@ -117,6 +119,12 @@ func TestHelloWorldFromShell(t *testing.T) {
 	outputString := ""
 	timeout = servingTimeout
 	for outputString != helloWorldExpectedOutput && timeout >= 0 {
+		var describeOutput []byte
+		if describeOutput, err = exec.Command("kubectl", "describe", "revision", "-n", test.ServingNamespace).CombinedOutput(); err != nil {
+			t.Fatalf("Error running kubectl: %v", strings.TrimSpace(string(describeOutput)))
+		}
+		logger.Infof("Revisions:\n%s", describeOutput)
+
 		var cmd *exec.Cmd
 		if test.ServingFlags.ResolvableDomain {
 			cmd = exec.Command("curl", serviceHost)

--- a/test/e2e/helloworld_shell_test.go
+++ b/test/e2e/helloworld_shell_test.go
@@ -75,8 +75,8 @@ func TestHelloWorldFromShell(t *testing.T) {
 		t.Fatalf("Failed to read file %s: %v", appYaml, err)
 	}
 
-	content := strings.Replace(string(yamlBytes), yamlImagePlaceholder, imagePath, -1)
-	content = strings.Replace(string(content), namespacePlaceholder, test.ServingNamespace, -1)
+	content := strings.Replace(string(yamlBytes), namespacePlaceholder, test.ServingNamespace, -1)
+	content = strings.Replace(string(content), yamlImagePlaceholder, imagePath, -1)
 
 	logger.Infof("New manifest contents are:\n%s", content)
 

--- a/test/util.go
+++ b/test/util.go
@@ -32,5 +32,5 @@ func LogResourceObject(logger *logging.BaseLogger, value ResourceObjects) {
 
 // ImagePath is a helper function to prefix image name with repo and suffix with tag
 func ImagePath(name string) string {
-	return fmt.Sprintf("%s:test-%s", ServingFlags.DockerRepo, name)
+	return fmt.Sprintf("%s/%s:%s", ServingFlags.DockerRepo, name, ServingFlags.Tag)
 }


### PR DESCRIPTION
This change tags all CI-built images into the OpenShift internal
registry in the format expected by Knative - ie `controller:latest`
versus `stable:controller`. And it updates all image references to
point to the internal registry instead of
`registry.svc.ci.openshift.org`.

I'm not sure this will actually work, but let's find out.