### PR TITLE
Use origin-v3.11:base as the base image

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD ${bin} /usr/bin/${bin}
 ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD activator /usr/bin/activator
 ENTRYPOINT ["/usr/bin/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD autoscaler /usr/bin/autoscaler
 ENTRYPOINT ["/usr/bin/autoscaler"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD queue /usr/bin/queue
 ENTRYPOINT ["/usr/bin/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD webhook /usr/bin/webhook
 ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD autoscale /usr/bin/autoscale
 ENTRYPOINT ["/usr/bin/autoscale"]

--- a/openshift/ci-operator/knative-test-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-test-images/envvars/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/envvars/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD envvars /usr/bin/envvars
 ENTRYPOINT ["/usr/bin/envvars"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD helloworld /usr/bin/helloworld
 ENTRYPOINT ["/usr/bin/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD httpproxy /usr/bin/httpproxy
 ENTRYPOINT ["/usr/bin/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD pizzaplanetv1 /usr/bin/pizzaplanetv1
 ENTRYPOINT ["/usr/bin/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD pizzaplanetv2 /usr/bin/pizzaplanetv2
 ENTRYPOINT ["/usr/bin/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM gcr.io/distroless/base:latest
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD singlethreaded /usr/bin/singlethreaded
 ENTRYPOINT ["/usr/bin/singlethreaded"]


### PR DESCRIPTION
* Use registry.svc.ci.openshift.org/openshift/origin-v3.11:base as the
base image. The FROM clause is ignored by ci-operator during the actual
build and is replaced by an image from ci-operator's config. Anyway,
it's replaced with the same image name so here we only make sure the
user knows what the base image is.