### PR TITLE
Get knative 0.3 to pass on OpenShift 4.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -30,8 +29,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/pkg/signals"
+
+	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/pkg/websocket"
 	"github.com/knative/serving/cmd/util"
 	activatorutil "github.com/knative/serving/pkg/activator/util"
@@ -44,7 +44,6 @@ import (
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -324,39 +323,39 @@ func main() {
 		fmt.Sprintf(":%d", v1alpha1.RequestQueuePort),
 		queue.TimeToFirstByteTimeoutHandler(http.HandlerFunc(handler), time.Duration(revisionTimeoutSeconds)*time.Second, "request timeout"))
 
-	// An `ErrServerClosed` should not trigger an early exit of
-	// the errgroup below.
-	catchServerError := func(runner func() error) func() error {
-		return func() error {
-			err := runner()
-			if err != http.ErrServerClosed {
-				return err
-			}
-			return nil
+	errChan := make(chan error, 2)
+	// Runs a server created by creator and sends fatal errors to the errChan.
+	// Does not act on the ErrServerClosed error since that indicates we're
+	// already shutting everything down.
+	catchServerError := func(creator func() error) {
+		if err := creator(); err != nil && err != http.ErrServerClosed {
+			errChan <- err
 		}
 	}
 
-	var g errgroup.Group
-	g.Go(catchServerError(server.ListenAndServe))
-	g.Go(catchServerError(adminServer.ListenAndServe))
-	g.Go(func() error {
-		<-signals.SetupSignalHandler()
-		return errors.New("Received SIGTERM")
-	})
+	go catchServerError(server.ListenAndServe)
+	go catchServerError(adminServer.ListenAndServe)
 
-	if err := g.Wait(); err != nil {
-		logger.Error("Shutting down", zap.Error(err))
-	}
+	// Blocks until we actually receive a TERM signal or one of the servers
+	// exit unexpectedly. We fold both signals together because we only want
+	// to act on the first of those to reach here.
+	select {
+	case err := <-errChan:
+		logger.Errorw("Failed to bring up queue-proxy, shutting down.", zap.Error(err))
+		os.Exit(1)
+	case <-signals.SetupSignalHandler():
+		logger.Info("Received TERM signal, attempting to gracefully shutdown servers.")
 
-	// Calling server.Shutdown() allows pending requests to
-	// complete, while no new work is accepted.
-	if err := adminServer.Shutdown(context.Background()); err != nil {
-		logger.Error("Failed to shutdown admin-server", zap.Error(err))
-	}
+		// Calling server.Shutdown() allows pending requests to
+		// complete, while no new work is accepted.
+		if err := adminServer.Shutdown(context.Background()); err != nil {
+			logger.Errorw("Failed to shutdown admin-server", zap.Error(err))
+		}
 
-	if statSink != nil {
-		if err := statSink.Close(); err != nil {
-			logger.Error("Failed to shutdown websocket connection", zap.Error(err))
+		if statSink != nil {
+			if err := statSink.Close(); err != nil {
+				logger.Errorw("Failed to shutdown websocket connection", zap.Error(err))
+			}
 		}
 	}
 }

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,15 +1,16 @@
-#!/bin/sh 
+#!/usr/bin/env bash
 
 source $(dirname $0)/../test/cluster.sh
 
 set -x
 
+readonly ENABLE_ADMISSION_WEBHOOKS="${ENABLE_ADMISSION_WEBHOOKS:-"true"}"
 readonly K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
 readonly API_SERVER=$(oc config view --minify | grep server | awk -F'//' '{print $2}' | awk -F':' '{print $1}')
-readonly INTERNAL_REGISTRY="docker-registry.default.svc:5000"
+readonly INTERNAL_REGISTRY="${INTERNAL_REGISTRY:-"docker-registry.default.svc:5000"}"
 readonly USER=$KUBE_SSH_USER #satisfy e2e_flags.go#initializeFlags()
 readonly OPENSHIFT_REGISTRY="${OPENSHIFT_REGISTRY:-"registry.svc.ci.openshift.org"}"
-readonly SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-"~/.ssh/google_compute_engine"}"
+readonly SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-"$HOME/.ssh/google_compute_engine"}"
 readonly INSECURE="${INSECURE:-"false"}"
 readonly ISTIO_YAML=$(find third_party -mindepth 1 -maxdepth 1 -type d -name "istio-*")/istio.yaml
 readonly ISTIO_CRD_YAML=$(find third_party -mindepth 1 -maxdepth 1 -type d -name "istio-*")/istio-crds.yaml
@@ -24,7 +25,7 @@ function enable_admission_webhooks(){
   disable_strict_host_checking
   echo "API_SERVER=$API_SERVER"
   echo "KUBE_SSH_USER=$KUBE_SSH_USER"
-  chmod 600 ~/.ssh/google_compute_engine
+  chmod 600 $SSH_PRIVATE_KEY
   echo "$API_SERVER ansible_ssh_private_key_file=${SSH_PRIVATE_KEY}" > inventory.ini
   ansible-playbook ${REPO_ROOT_DIR}/openshift/admission-webhooks.yaml -i inventory.ini -u $KUBE_SSH_USER
   rm inventory.ini
@@ -43,6 +44,72 @@ Host *
    StrictHostKeyChecking no
    UserKnownHostsFile=/dev/null
 EOF
+}
+
+function scale_up_workers(){
+  local cluster_api_ns="openshift-machine-api"
+  # Get the name of the first machineset that has at least 1 replica
+  local machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" -l machine.openshift.io/cluster-api-machine-type=worker | grep " 1" | head -n 1 | awk '{print $1}')
+  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
+  oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6
+}
+
+# Waits until the machineset in the given namespaces scales up to the
+# desired number of replicas
+# Parameters: $1 - namespace
+#             $2 - machineset name
+#             $3 - desired number of replicas
+function wait_until_machineset_scales_up() {
+  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
+  for i in {1..150}; do  # timeout after 15 minutes
+    local available=$(oc get machineset -n $1 $2 -o jsonpath="{.status.availableReplicas}")
+    if [[ ${available} -eq $3 ]]; then
+      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo - "\n\nError: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  return 1
+}
+
+# Waits until the given hostname resolves via DNS
+# Parameters: $1 - hostname
+function wait_until_hostname_resolves() {
+  echo -n "Waiting until hostname $1 resolves via DNS"
+  for i in {1..150}; do  # timeout after 15 minutes
+    local output="$(host -t a $1 | grep 'has address')"
+    if [[ -n "${output}" ]]; then
+      echo -e "\n${output}"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\nERROR: timeout waiting for hostname $1 to resolve via DNS"
+  return 1
+}
+
+# Waits until the configmap in the given namespace contains the
+# desired content.
+# Parameters: $1 - namespace
+#             $2 - configmap name
+#             $3 - desired content
+function wait_until_configmap_contains() {
+  echo -n "Waiting until configmap $1/$2 contains '$3'"
+  for _ in {1..180}; do  # timeout after 3 minutes
+    local output="$(oc -n "$1" get cm "$2" -oyaml | grep "$3")"
+    if [[ -n "${output}" ]]; then
+      echo -e "\n${output}"
+      return 0
+    fi
+    echo -n "."
+    sleep 1
+  done
+  echo -e "\n\nERROR: timeout waiting for configmap $1/$2 to contain '$3'"
+  return 1
 }
 
 function install_istio(){
@@ -88,13 +155,37 @@ function install_knative(){
 
   # Deploy Knative Serving from the current source repository. This will also install Knative Build.
   create_serving_and_build
+  enable_knative_interaction_with_registry
 
   echo ">> Patching Istio"
-  oc patch hpa -n istio-system knative-ingressgateway --patch '{"spec": {"maxReplicas": 1}}'
+  for gateway in istio-ingressgateway knative-ingressgateway cluster-local-gateway istio-egressgateway; do
+    if kubectl get svc -n istio-system ${gateway} > /dev/null 2>&1 ; then
+      kubectl patch hpa -n istio-system ${gateway} --patch '{"spec": {"maxReplicas": 1}}'
+      kubectl set resources deploy -n istio-system ${gateway} \
+        -c=istio-proxy --requests=cpu=50m 2> /dev/null
+    fi
+  done
+
+  # There are reports of Envoy failing (503) when istio-pilot is overloaded.
+  # We generously add more pilot instances here to verify if we can reduce flakes.
+  if kubectl get hpa -n istio-system istio-pilot 2>/dev/null; then
+    # If HPA exists, update it.  Since patching will return non-zero if no change
+    # is made, we don't return on failure here.
+    kubectl patch hpa -n istio-system istio-pilot \
+      --patch '{"spec": {"minReplicas": 3, "maxReplicas": 10, "targetCPUUtilizationPercentage": 60}}' \
+      `# Ignore error messages to avoid causing red herrings in the tests` \
+      2>/dev/null
+  else
+    # Some versions of Istio doesn't provide an HPA for pilot.
+    kubectl autoscale -n istio-system deploy istio-pilot --min=3 --max=10 --cpu-percent=60 || return 1
+  fi
 
   wait_until_pods_running knative-build || return 1
   wait_until_pods_running knative-serving || return 1
   wait_until_service_has_external_ip istio-system knative-ingressgateway || fail_test "Ingress has no external IP"
+
+  wait_until_hostname_resolves $(kubectl get svc -n istio-system knative-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+
   header "Knative Installed successfully"
 }
 
@@ -107,9 +198,18 @@ function create_serving_and_build(){
   
   # Remove nodePort spec as the ports do not fall into the range allowed by OpenShift
   sed '/nodePort/d' serving-resolved.yaml | oc apply -f -
+}
 
-  echo ">>> Setting SSL_CERT_FILE for Knative Serving Controller"
-  oc set env -n knative-serving deployment/controller SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+function enable_knative_interaction_with_registry() {
+  local configmap_name=config-service-ca
+  local cert_name=service-ca.crt
+  local mount_path=/var/run/secrets/kubernetes.io/servicecerts
+
+  oc -n $SERVING_NAMESPACE create configmap $configmap_name
+  oc -n $SERVING_NAMESPACE annotate configmap $configmap_name service.alpha.openshift.io/inject-cabundle="true"
+  wait_until_configmap_contains $SERVING_NAMESPACE $configmap_name $cert_name
+  oc -n $SERVING_NAMESPACE set volume deployment/controller --add --name=service-ca --configmap-name=$configmap_name --mount-path=$mount_path
+  oc -n $SERVING_NAMESPACE set env deployment/controller SSL_CERT_FILE=$mount_path/$cert_name
 }
 
 function create_test_resources_openshift() {
@@ -161,20 +261,23 @@ function run_e2e_tests(){
   header "Running tests"
   options=""
   (( EMIT_METRICS )) && options="-emitmetrics"
+  failed=0
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -short \
     ./test/e2e \
     --kubeconfig $KUBECONFIG \
     --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \
-    ${options} || return 1
+    ${options} || failed=1
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m \
     ./test/conformance \
     --kubeconfig $KUBECONFIG \
     --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \
-    ${options} || return 1
+    ${options} || failed=1
+
+  return $failed
 }
 
 function delete_istio_openshift(){
@@ -226,7 +329,11 @@ function tag_built_image() {
   oc tag --insecure=${INSECURE} -n ${SERVING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${remote_name} ${local_name}:latest
 }
 
-enable_admission_webhooks
+if [[ $ENABLE_ADMISSION_WEBHOOKS == "true" ]]; then
+  enable_admission_webhooks
+fi
+
+scale_up_workers
 
 create_test_namespace
 

--- a/third_party/istio-1.0.2/istio.yaml
+++ b/third_party/istio-1.0.2/istio.yaml
@@ -347,11 +347,11 @@ data:
       
       containers:
       - name: istio-proxy
-        # PATCH #2: Graceful shutdown of the istio-proxy.
+        # PATCH #2: Graceful shutdown of the istio-proxy. See https://github.com/istio/istio/issues/7136.
         lifecycle:
           preStop:
             exec:
-              command: ["sh", "-c", 'sleep 20; until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+              command: ["sh", "-c", 'sleep 20; while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l | xargs) -ne 0 ]; do sleep 1; done']
         # PATCH #2 ends.
         image: [[ if (isset .ObjectMeta.Annotations "sidecar.istio.io/proxyImage") -]]
         "[[ index .ObjectMeta.Annotations "sidecar.istio.io/proxyImage" ]]"

--- a/third_party/istio-1.0.2/prestop-sleep.yaml.patch
+++ b/third_party/istio-1.0.2/prestop-sleep.yaml.patch
@@ -1,7 +1,7 @@
 349a350,355
->         # PATCH #2: Graceful shutdown of the istio-proxy.
+>         # PATCH #2: Graceful shutdown of the istio-proxy. See https://github.com/istio/istio/issues/7136.
 >         lifecycle:
 >           preStop:
 >             exec:
->               command: ["sh", "-c", 'sleep 20; until curl -s localhost:15000/clusters | grep "inbound|80|" | grep "rq_active" | grep "rq_active::0"; do sleep 1; done;']
+>               command: ["sh", "-c", 'sleep 20; while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l | xargs) -ne 0 ]; do sleep 1; done']
 >         # PATCH #2 ends.

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -141,21 +141,26 @@ function wait_until_pods_running() {
   return 1
 }
 
-# Waits until the given service has an external IP address.
+# Waits until the given service has an external address (IP/hostname).
 # Parameters: $1 - namespace.
 #             $2 - service name.
 function wait_until_service_has_external_ip() {
-  echo -n "Waiting until service $2 in namespace $1 has an external IP"
+  echo -n "Waiting until service $2 in namespace $1 has an external address (IP/hostname)"
   for i in {1..150}; do  # timeout after 15 minutes
     local ip=$(kubectl get svc -n $1 $2 -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
     if [[ -n "${ip}" ]]; then
       echo -e "\nService $2.$1 has IP $ip"
       return 0
     fi
+    local hostname=$(kubectl get svc -n $1 $2 -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+    if [[ -n "${hostname}" ]]; then
+      echo -e "\nService $2.$1 has hostname $hostname"
+      return 0
+    fi
     echo -n "."
     sleep 6
   done
-  echo -e "\n\nERROR: timeout waiting for service $svc.$ns to have an external IP"
+  echo -e "\n\nERROR: timeout waiting for service $2.$1 to have an external address"
   kubectl get pods -n $1
   return 1
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* **Backport library fix to also work with hostnames.**
* **Various fixes to the e2e-tests script.**
  - Scale workers up before running tests to alleviate capacity issues.
  - Wait until the hostname resolves after setting up the ingressgateway.
  - Run both test suites even if the first one fails, report an aggregated error.
  - Port upstream istio resource adjustments.
* **Backport quick shutdown fix.** This helps alleviate capacity issues because pods don't stay along for 5 minutes even after tests are already finished.
* **Port ip/hostname fix for shell test and use 'oc' commands in it.**
  - This test had various fixes upstream.
  - Replaced `kubectl` with `oc` to fix a version mismatch in `kubectl` and also gain test-coverage for `oc` based commands.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
