### PR TITLE
Make the 0.4.1 release work.

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source $(dirname $0)/../test/cluster.sh
+source $(dirname $0)/../test/e2e-common.sh
 
 set -x
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -198,7 +198,7 @@ function install_knative(){
   enable_knative_interaction_with_registry
 
   echo ">> Patching Istio"
-  for gateway in istio-ingressgateway knative-ingressgateway cluster-local-gateway istio-egressgateway; do
+  for gateway in istio-ingressgateway cluster-local-gateway istio-egressgateway; do
     if kubectl get svc -n istio-system ${gateway} > /dev/null 2>&1 ; then
       kubectl patch hpa -n istio-system ${gateway} --patch '{"spec": {"maxReplicas": 1}}'
       kubectl set resources deploy -n istio-system ${gateway} \
@@ -222,9 +222,9 @@ function install_knative(){
 
   wait_until_pods_running knative-build || return 1
   wait_until_pods_running knative-serving || return 1
-  wait_until_service_has_external_ip istio-system knative-ingressgateway || fail_test "Ingress has no external IP"
+  wait_until_service_has_external_ip istio-system istio-ingressgateway || fail_test "Ingress has no external IP"
 
-  wait_until_hostname_resolves $(kubectl get svc -n istio-system knative-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+  wait_until_hostname_resolves $(kubectl get svc -n istio-system istio-ingressgateway -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
 
   header "Knative Installed successfully"
 }

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -193,6 +193,9 @@ function install_knative(){
   oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
   oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
 
+  oc adm policy add-scc-to-user anyuid -z build-pipeline-controller -n knative-build-pipeline
+  oc adm policy add-cluster-role-to-user cluster-admin -z build-pipeline-controller -n knative-build-pipeline
+
   # Deploy Knative Serving from the current source repository. This will also install Knative Build.
   create_serving_and_build
   enable_knative_interaction_with_registry
@@ -232,6 +235,7 @@ function install_knative(){
 function create_serving_and_build(){
   echo ">> Bringing up Build and Serving"
   oc apply -f third_party/config/build/release.yaml
+  oc apply -f third_party/config/pipeline/release.yaml
   
   > serving-resolved.yaml
   resolve_resources config/ $SERVING_NAMESPACE serving-resolved.yaml
@@ -326,6 +330,7 @@ function delete_serving_openshift() {
   echo ">> Bringing down Serving"
   oc delete --ignore-not-found=true -f serving-resolved.yaml
   oc delete --ignore-not-found=true -f third_party/config/build/release.yaml
+  oc delete --ignore-not-found=true -f third_party/config/pipeline/release.yaml
 }
 
 function delete_test_resources_openshift() {

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -300,14 +300,14 @@ function run_e2e_tests(){
   failed=0
 
   report_go_test \
-    -v -tags=e2e -count=1 -timeout=35m -short \
+    -v -tags=e2e -count=1 -timeout=35m -short -parallel=1 \
     ./test/e2e \
     --kubeconfig $KUBECONFIG \
     --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \
     ${options} || failed=1
 
   report_go_test \
-    -v -tags=e2e -count=1 -timeout=35m \
+    -v -tags=e2e -count=1 -timeout=35m -parallel=1 \
     ./test/conformance \
     --kubeconfig $KUBECONFIG \
     --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -75,18 +75,24 @@ func getGatewayIP(kube *kubernetes.Clientset) (string, error) {
 	const ingressName = "istio-ingressgateway"
 	const ingressNamespace = "istio-system"
 
-	ingress, err := kube.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
+	svc, err := kube.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
-	if len(ingress.Status.LoadBalancer.Ingress) != 1 {
-		return "", fmt.Errorf("expected exactly one ingress load balancer, instead had %d: %s",
-			len(ingress.Status.LoadBalancer.Ingress), ingress.Status.LoadBalancer.Ingress)
+	ingresses := svc.Status.LoadBalancer.Ingress
+	if len(ingresses) != 1 {
+		return "", fmt.Errorf("Expected exactly one ingress load balancer, instead had %d: %v", len(ingresses), ingresses)
 	}
-	if ingress.Status.LoadBalancer.Ingress[0].IP == "" {
-		return "", fmt.Errorf("expected ingress loadbalancer IP for %s to be set, instead was empty", ingressName)
+	itu := ingresses[0]
+
+	switch {
+	case itu.IP != "":
+		return itu.IP, nil
+	case itu.Hostname != "":
+		return itu.Hostname, nil
+	default:
+		return "", fmt.Errorf("Expected ingress loadbalancer IP or hostname for %s to be set, instead was empty", svc.Name)
 	}
-	return ingress.Status.LoadBalancer.Ingress[0].IP, nil
 }
 
 func validateWebSocketConnection(t *testing.T, clients *test.Clients, names test.ResourceNames) error {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Pick up renamed script.
* Drop references to knative-ingressgateway.
* Don't run tests in parallel.
* Also install pipelines in end-to-end test.
* Fix websocket test by allowing both hostname and ip. (Fixed upstream in the next release)