### PR TITLE
Add script to automatically create and update release branches.

### DIFF
--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -10,12 +10,14 @@ As far as branching goes, we have two use-cases:
 A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
 that points to the upstream repository and a remote "openshift" that points to the openshift fork.
 
+Run the scripts from the root of the repository.
+
 ### Creating a branch based off an upstream release tag
 
 To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
 
 ```bash
-$ ./create-release-branch.sh v0.4.1 release-0.4
+$ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
 ```
 
 This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
@@ -26,7 +28,7 @@ files that we need to run CI on top of it.
 To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
 
 ```bash
-$ ./update-to-head.sh release-0.5
+$ ./openshift/release/update-to-head.sh release-0.5
 ```
 
 That will pull the latest master from upstream, rebase the current fixes on the release-0.5 branch

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -1,0 +1,33 @@
+# Release creation
+
+## Branching
+
+As far as branching goes, we have two use-cases:
+
+1. Creating a branch based off an upstream release tag.
+2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
+
+A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
+that points to the upstream repository.
+
+### Creating a branch based off an upstream release tag
+
+To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
+
+```bash
+$ ./create-release-branch.sh v0.4.1 release-0.4
+```
+
+This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
+files that we need to run CI on top of it.
+
+### Updating a branch that follow upstream's HEAD
+
+To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
+
+```bash
+$ ./update-to-head.sh release-0.5
+```
+
+That will pull the latest master from upstream, rebase the current fixes on the release-0.5 branch
+on top of it and update the Openshift specific files if necessary.

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -8,7 +8,7 @@ As far as branching goes, we have two use-cases:
 2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
 
 A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
-that points to the upstream repository.
+that points to the upstream repository and a remote "openshift" that points to the openshift fork.
 
 ### Creating a branch based off an upstream release tag
 

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage: create-release-branch.sh v0.4.1 release-0.4
+
+release=$1
+target=$2
+
+git fetch upstream --tags
+git checkout -b "$target" "$release"
+
+git checkout master openshift OWNERS_ALIASES OWNERS Makefile
+make generate-dockerfiles
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m "Add openshift specific files."

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -5,10 +5,13 @@
 release=$1
 target=$2
 
+# Fetch the latest tags and checkout a new branch from the wanted tag.
 git fetch upstream --tags
 git checkout -b "$target" "$release"
 
-git checkout master openshift OWNERS_ALIASES OWNERS Makefile
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage: update-to-head.sh release-0.5
+
+target=$1
+
+git checkout "$target"
+git fetch upstream master
+git rebase upstream/master
+
+git checkout master openshift OWNERS_ALIASES OWNERS Makefile
+make generate-dockerfiles
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m "Update openshift specific files."

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -4,11 +4,16 @@
 
 target=$1
 
+# Checkout the target branch.
 git checkout "$target"
+
+# Update upstream's master and rebase on top of it.
 git fetch upstream master
 git rebase upstream/master
 
-git checkout master openshift OWNERS_ALIASES OWNERS Makefile
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Update openshift specific files."


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

As per title, this adds two scripts:

1. To create a release branch based on an upstream release tag.
2. To update a given release branch to upstream's HEAD (for the branch currently following master).
