### PR TITLE
Allow builds to be used in a kservice [SRVCOM-428]

### DIFF
--- a/openshift/olm/knative-serving.v0.4.1.clusterserviceversion.yaml
+++ b/openshift/olm/knative-serving.v0.4.1.clusterserviceversion.yaml
@@ -178,6 +178,18 @@ spec:
           - patch
           - watch
         - apiGroups:
+          - build.knative.dev
+          resources:
+          - builds
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - patch
+          - watch
+        - apiGroups:
           - networking.istio.io
           resources:
           - virtualservices


### PR DESCRIPTION
Apparently, as of 0.4.0, upstream requires a third resource to be
applied if you want to use build with serving:
https://github.com/knative/serving/blob/master/third_party/config/build/clusterrole.yaml

This is due to them now using aggregationRules for their
cross-component ClusterRoles:
https://github.com/knative/serving/pull/3238

The OLM CSV doesn't support this, so we have to be explicit.
