### PR TITLE
Apparently, the 'replaces' field must refer to a CSV within the CS

### DIFF
--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -260,7 +260,6 @@ data:
           Knative Serving builds on Kubernetes and Istio to support deploying and serving of serverless applications and functions
         version: 0.4.1
         maturity: alpha
-        replaces: knative-serving.v0.3.0
 
         installModes:
         - supported: true

--- a/openshift/olm/knative-serving.v0.4.1.clusterserviceversion.yaml
+++ b/openshift/olm/knative-serving.v0.4.1.clusterserviceversion.yaml
@@ -8,7 +8,6 @@ spec:
     Knative Serving builds on Kubernetes and Istio to support deploying and serving of serverless applications and functions
   version: 0.4.1
   maturity: alpha
-  replaces: knative-serving.v0.3.0
   
   installModes:
   - supported: true


### PR DESCRIPTION
I assumed it could be in any registered CS, but I was wrong. Testing
this CS yielded the following:
"Error: knative-serving.v0.4.1 specifies replacement that couldn't be found"
