### PR TITLE
Add build and pipeline entities to the ServiceAccount.

### DIFF
--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -429,6 +429,34 @@ data:
                 - patch
                 - watch
               - apiGroups:
+                - build.knative.dev
+                resources:
+                - builds
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
+                - pipeline.knative.dev
+                resources:
+                - pipelines
+                - tasks
+                - pipelineresources
+                - pipelineruns
+                - taskruns
+                verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - patch
+                - watch
+              - apiGroups:
                 - networking.istio.io
                 resources:
                 - virtualservices


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

As per title. This also fixes the catalogsource, which was missed in an earlier PR.
