### PR TITLE
Update forked repo synching automation

### DIFF
--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -23,13 +23,13 @@ $ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
 This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
 files that we need to run CI on top of it.
 
-### Updating a branch that follow upstream's HEAD
+### Updating the release-next branch that follow upstream's HEAD
 
 To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
 
 ```bash
-$ ./openshift/release/update-to-head.sh release-0.5
+$ ./openshift/release/update-to-head.sh
 ```
 
-That will pull the latest master from upstream, rebase the current fixes on the release-0.5 branch
-on top of it and update the Openshift specific files if necessary.
+That will pull the latest master from upstream, rebase the current fixes on the release-next branch
+on top of it, update the Openshift specific files if necessary, and then trigger CI.

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,15 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Usage: update-to-head.sh release-0.5
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
 
-target=$1
-
-# Checkout the target branch.
-git checkout "$target"
-
-# Update upstream's master and rebase on top of it.
-git fetch upstream master
-git rebase upstream/master
+# Reset release-next to upstream/master.
+git checkout upstream/master -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
@@ -17,3 +12,16 @@ git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Update openshift specific files."
+git push -f openshift release-next
+
+git checkout release-next -B release-next-ci
+date > ci
+git add ci
+git commit -m "Triggering CI on branch 'release-next' after synching to head"
+git push -f openshift release-next-ci
+
+if hash hub 2>/dev/null; then
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift:release-next -h openshift:release-next-ci
+else
+   echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
+fi


### PR DESCRIPTION
The new 'release-next' branch will track upstream/master and is where
CI will be run on a periodic basis.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
