### PR TITLE
Update synch automation script again

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -4,7 +4,9 @@
 # Usage: update-to-head.sh
 
 # Reset release-next to upstream/master.
-git checkout upstream/master -B release-next
+git checkout release-next
+git fetch upstream master
+git reset --hard upstream/master
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
@@ -14,10 +16,11 @@ git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Update openshift specific files."
 git push -f openshift release-next
 
+# Trigger CI
 git checkout release-next -B release-next-ci
 date > ci
 git add ci
-git commit -m "Triggering CI on branch 'release-next' after synching to head"
+git commit -m "Triggering CI on branch 'release-next' after synching to upstream/master"
 git push -f openshift release-next-ci
 
 if hash hub 2>/dev/null; then


### PR DESCRIPTION
Reset release-next branch to upstream/master
Add the openshift files from openshift/master
Force push to the release-next branch
Triigger CI

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
