### PR TITLE
Add the newly added networking controller to the images to build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/controller ./cmd/queue ./cmd/webhook
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) ./test/controller
 
 install:

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD istio /usr/bin/istio
+ENTRYPOINT ["/usr/bin/istio"]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Same fix that already made release-next pass. We need it on master to be picked up for future releases.
