### PR TITLE
Generate knative-serving-ci.yaml for CI

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -14,5 +14,6 @@ git fetch openshift master
 git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make RELEASE=$release generate-release
+make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -3,8 +3,14 @@
 source $(dirname $0)/resolve.sh
 
 release=$1
-
-quay_image_prefix="quay.io/openshift-knative/knative-serving-"
 output_file="openshift/release/knative-serving-${release}.yaml"
 
-resolve_resources config/ $output_file $quay_image_prefix $release
+if [ $release = "ci" ]; then
+    image_prefix="image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-"
+    tag=""
+else
+    image_prefix="quay.io/openshift-knative/knative-serving-"
+    tag=$release
+fi
+
+resolve_resources config/ $output_file $image_prefix $tag

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -12,6 +12,7 @@ git reset --hard upstream/master
 git fetch openshift master
 git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
+make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Update openshift specific files."
 git push -f openshift release-next


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* Generate knative-serving-ci.yaml for each branch. This file is intended to be used only for CI purposes as it contains references to images produced during CI build.



