### PR TITLE
Cherry pick e2e script fix.

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -49,8 +49,11 @@ EOF
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"
+
+  oc get machineset -n ${cluster_api_ns} --show-labels
+
   # Get the name of the first machineset that has at least 1 replica
-  local machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" -l machine.openshift.io/cluster-api-machine-type=worker | grep " 1" | head -n 1 | awk '{print $1}')
+  local machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
   # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
   oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
   wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Needed fix for the e2e-test script based on OpenShift. Apparently the machinesets are no longer labeled granularly.
