### PR TITLE
chore(olm): Added finalizer perms to Deployments in "apps" group, too.

### DIFF
--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -971,6 +971,7 @@ data:
                 - use
               - apiGroups:
                 - extensions
+                - apps
                 resources:
                 - deployments/finalizers
                 verbs:
@@ -978,7 +979,6 @@ data:
               - apiGroups:
                 - serving.knative.dev
                 - networking.internal.knative.dev
-                - admissionregistration.k8s.io
                 resources:
                 - '*/finalizers'
                 verbs:


### PR DESCRIPTION
Fixes SRVKS-82 (tested on OCP4).
Also, removed the admissioncontroller group as this is not necessary.
Furthermore, one could consider to remove the "extensions" group as this
is the legacy group for "Deployment". Not sure if knative is using this
apigroup at all.

