### PR TITLE
Simplify resetting to upstream/master

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -3,10 +3,12 @@
 # Synchs the release-next branch to master and then triggers CI
 # Usage: update-to-head.sh
 
+set -e
+REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+
 # Reset release-next to upstream/master.
-git checkout release-next
 git fetch upstream master
-git reset --hard upstream/master
+git checkout upstream/master -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
@@ -25,7 +27,7 @@ git commit -m "Triggering CI on branch 'release-next' after synching to upstream
 git push -f openshift release-next-ci
 
 if hash hub 2>/dev/null; then
-   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift:release-next -h openshift:release-next-ci
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
 else
    echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
 fi


### PR DESCRIPTION
This change means that the script will work the first time it is run
when the release-next branch doesn't exist.