### PR TITLE
Remove CRI-O bandaid.

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -178,13 +178,6 @@ function install_knative(){
 
   enable_knative_interaction_with_registry
 
-  # Disable docker.io sha resolving.
-  # TODO: Fix CRI-O bug and remove this once that lands.
-  kubectl patch configmap/config-deployment \
-    -n knative-serving \
-    --type merge \
-    -p '{"data":{"registriesSkippingTagResolving":"ko.local,dev.local,docker.io,index.docker.io"}}'
-
   echo ">> Patching Istio"
   for gateway in istio-ingressgateway cluster-local-gateway istio-egressgateway; do
     if kubectl get svc -n istio-system ${gateway} > /dev/null 2>&1 ; then


### PR DESCRIPTION
As per title. A fix has been merged upstream to unblock CRI-O based clusters. https://github.com/knative/serving/commit/ce9bdcb8f2515206eb4ad4518012ff7d2c794b1a