### PR TITLE
Remove deleted image.

### DIFF
--- a/openshift/ci-operator/knative-test-images/environment/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/environment/Dockerfile
@@ -1,5 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-
-ADD environment /usr/bin/environment
-ENTRYPOINT ["/usr/bin/environment"]


### PR DESCRIPTION
As per title. This image is no longer needed. Removing it to automatically remove it when generating ci config.