### PR TITLE
Install core binaries sequentially.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/controller ./cmd/queue ./cmd/
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) ./test/controller
 
 install:
-	go install $(CORE_IMAGES)
+	for img in $(CORE_IMAGES); do \
+		go install $$img ; \
+	done
 .PHONY: install
 
 test-install:


### PR DESCRIPTION
As per title. This makes the image build more stable cause it doesn't use as much memory and isn't prone to OOMs.