### PR TITLE
Add a mechanism to provide patches that are carried over.

### DIFF
--- a/openshift/patches/001-servicetoservice.patch
+++ b/openshift/patches/001-servicetoservice.patch
@@ -1,0 +1,20 @@
+diff --git a/test/e2e/service_to_service_test.go b/test/e2e/service_to_service_test.go
+index bd1d23dc..1b6bafd5 100644
+--- a/test/e2e/service_to_service_test.go
++++ b/test/e2e/service_to_service_test.go
+@@ -136,6 +136,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldDomain
+ // The expected result is that the request sent to httpproxy app is successfully redirected
+ // to helloworld app.
+ func TestServiceToServiceCall(t *testing.T) {
++	t.Skip("Known to be broken in non-mesh cases.")
+ 	t.Parallel()
+ 	clients := Setup(t)
+ 
+@@ -179,6 +180,7 @@ func TestServiceToServiceCall(t *testing.T) {
+ // Same test as TestServiceToServiceCall but before sending requests
+ // we're waiting for target app to be scaled to zero
+ func TestServiceToServiceCallFromZero(t *testing.T) {
++	t.Skip("Known to be broken in non-mesh cases.")
+ 	t.Parallel()
+ 	clients := Setup(t)
+ 

--- a/openshift/patches/002-runaspid.patch
+++ b/openshift/patches/002-runaspid.patch
@@ -1,0 +1,12 @@
+diff --git a/test/conformance/user_test.go b/test/conformance/user_test.go
+index 1166a54d..f0529837 100644
+--- a/test/conformance/user_test.go
++++ b/test/conformance/user_test.go
+@@ -67,6 +67,7 @@ func TestMustRunAsUser(t *testing.T) {
+ // in the Dockerfile is respected when executed in Knative as declared by "SHOULD"
+ // in the runtime-contract.
+ func TestShouldRunAsUserContainerDefault(t *testing.T) {
++	t.Skip("Known not to work on OCP as is.")
+ 	t.Parallel()
+ 	clients := setup(t)
+ 	_, ri, err := fetchRuntimeInfoUnprivileged(t, clients, &test.Options{})

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -17,6 +17,11 @@ make generate-dockerfiles
 make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m ":open_file_folder: Update openshift specific files."
+
+# Apply patches .
+git apply openshift/patches/*
+git commit -am ":fire: Apply carried patches."
+
 git push -f openshift release-next
 
 # Trigger CI


### PR DESCRIPTION
@alanfx, unfortunately, the time has come that we need this...

This adds a very crude mechanism to enable us to provide hot fixes and apply them to the repository after updating to head. All of these should only ever be temporary as we're looking to get them fixed upstream.