### PR TITLE
Fix path to conformance tests

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -203,7 +203,7 @@ function run_e2e_tests(){
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -parallel=1 \
-    ./test/conformance \
+    ./test/conformance/... \
     --kubeconfig $KUBECONFIG \
     --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \
     ${options} || failed=1


### PR DESCRIPTION
This patch changes to path from `/test/conformance` to
`/test/conformance/...` in `e2e-tests-openshift.sh`.

c.f. Upstream changed the path as:

https://github.com/knative/serving/blob/b245b49c5f35b1aea15cc4c4dd626687ec820a7b/test/e2e-tests.sh#L46-L52


And, here is the recent [build logs in pull/151](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_knative-serving/151/pull-ci-openshift-knative-serving-release-next-e2e/197/build-log.txt).

```
+ report_go_test -v -tags=e2e -count=1 -timeout=35m -parallel=1 ./test/conformance --kubeconfig /tmp/admin.kubeconfig --dockerrepo image-registry.openshift-image-registry.svc:5000/knative-serving
+ local 'args= -v -tags=e2e -count=1 -timeout=35m -parallel=1 ./test/conformance --kubeconfig /tmp/admin.kubeconfig --dockerrepo image-registry.openshift-image-registry.svc:5000/knative-serving '
+ local 'go_test=go test -race -v  -tags=e2e -count=1 -timeout=35m -parallel=1 ./test/conformance --kubeconfig /tmp/admin.kubeconfig --dockerrepo image-registry.openshift-image-registry.svc:5000/knative-serving '
+ echo 'Running tests with '\''go test -race -v  -tags=e2e -count=1 -timeout=35m -parallel=1 ./test/conformance --kubeconfig /tmp/admin.kubeconfig --dockerrepo image-registry.openshift-image-registry.svc:5000/knative-serving '\'''
++ mktemp
+ local report=/tmp/tmp.kzCaTHyDej
+ go test -race -v -tags=e2e -count=1 -timeout=35m -parallel=1 ./test/conformance --kubeconfig /tmp/admin.kubeconfig --dockerrepo image-registry.openshift-image-registry.svc:5000/knative-serving
+ tee /tmp/tmp.kzCaTHyDej
can't load package: package github.com/knative/serving/test/conformance: no Go files in /go/src/github.com/knative/serving/test/conformance
+ failed=(${PIPESTATUS[@]})
+ local failed
Finished run, return code is 1
```

Fixes https://jira.coreos.com/browse/SRVKS-146