### PR TITLE
Add uid 1000 to runtime-unprivileged's Dockerfile

### DIFF
--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -8,6 +8,10 @@ function generate_dockefiles() {
     local image_base=$(basename $img)
     mkdir -p $target_dir/$image_base
     bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    # Add USER 1000 to runtime-unprivileged image
+    if [[ $image_base = "runtime-unprivileged" ]]; then
+      sed -i '/FROM/a\USER 1000' $target_dir/$image_base/Dockerfile
+    fi
   done
 }
 

--- a/openshift/ci-operator/knative-test-images/runtime-unprivileged/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime-unprivileged/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 1000
+
+ADD runtime-unprivileged /usr/bin/runtime-unprivileged
+ENTRYPOINT ["/usr/bin/runtime-unprivileged"]


### PR DESCRIPTION
For `TestShouldRunAsUserContainerDefault`, `runtime-unprivileged` needs to
have a image that sets up and uses a non-root user (uid 1000).
This patch inserts `USER 1000` to runtime-unprivileged's Dockerfile.

c.f. upstream overrides ko config as
https://github.com/knative/serving/blob/master/.ko.yaml.