### PR TITLE
Add UID 65532 to run all containers as non-root user

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD ${bin} /usr/bin/${bin}
 ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -8,10 +8,6 @@ function generate_dockefiles() {
     local image_base=$(basename $img)
     mkdir -p $target_dir/$image_base
     bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
-    # Add USER 1000 to runtime-unprivileged image
-    if [[ $image_base = "runtime-unprivileged" ]]; then
-      sed -i '/FROM/a\USER 1000' $target_dir/$image_base/Dockerfile
-    fi
   done
 }
 

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD activator /usr/bin/activator
 ENTRYPOINT ["/usr/bin/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD autoscaler /usr/bin/autoscaler
 ENTRYPOINT ["/usr/bin/autoscaler"]

--- a/openshift/ci-operator/knative-images/certmanager/Dockerfile
+++ b/openshift/ci-operator/knative-images/certmanager/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD certmanager /usr/bin/certmanager
 ENTRYPOINT ["/usr/bin/certmanager"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD istio /usr/bin/istio
 ENTRYPOINT ["/usr/bin/istio"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD queue /usr/bin/queue
 ENTRYPOINT ["/usr/bin/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD webhook /usr/bin/webhook
 ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD autoscale /usr/bin/autoscale
 ENTRYPOINT ["/usr/bin/autoscale"]

--- a/openshift/ci-operator/knative-test-images/bloatingcow/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/bloatingcow/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD bloatingcow /usr/bin/bloatingcow
 ENTRYPOINT ["/usr/bin/bloatingcow"]

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD failing /usr/bin/failing
 ENTRYPOINT ["/usr/bin/failing"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD grpc-ping /usr/bin/grpc-ping
 ENTRYPOINT ["/usr/bin/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD hellovolume /usr/bin/hellovolume
 ENTRYPOINT ["/usr/bin/hellovolume"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD helloworld /usr/bin/helloworld
 ENTRYPOINT ["/usr/bin/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD httpproxy /usr/bin/httpproxy
 ENTRYPOINT ["/usr/bin/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD observed-concurrency /usr/bin/observed-concurrency
 ENTRYPOINT ["/usr/bin/observed-concurrency"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD pizzaplanetv1 /usr/bin/pizzaplanetv1
 ENTRYPOINT ["/usr/bin/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD pizzaplanetv2 /usr/bin/pizzaplanetv2
 ENTRYPOINT ["/usr/bin/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/printport/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/printport/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD printport /usr/bin/printport
 ENTRYPOINT ["/usr/bin/printport"]

--- a/openshift/ci-operator/knative-test-images/protocols/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/protocols/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD protocols /usr/bin/protocols
 ENTRYPOINT ["/usr/bin/protocols"]

--- a/openshift/ci-operator/knative-test-images/runtime-unprivileged/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime-unprivileged/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 1000
-
-ADD runtime-unprivileged /usr/bin/runtime-unprivileged
-ENTRYPOINT ["/usr/bin/runtime-unprivileged"]

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD runtime /usr/bin/runtime
 ENTRYPOINT ["/usr/bin/runtime"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD singlethreaded /usr/bin/singlethreaded
 ENTRYPOINT ["/usr/bin/singlethreaded"]

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD timeout /usr/bin/timeout
 ENTRYPOINT ["/usr/bin/timeout"]

--- a/openshift/ci-operator/knative-test-images/workingdir/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/workingdir/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD workingdir /usr/bin/workingdir
 ENTRYPOINT ["/usr/bin/workingdir"]

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -1,5 +1,6 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
 
 ADD wsserver /usr/bin/wsserver
 ENTRYPOINT ["/usr/bin/wsserver"]


### PR DESCRIPTION
This patch changes to
- adds UID 65532 to all Dockerfile for tests to follow up upstream's [pull/3237](https://github.com/knative/serving/commit/aa48603716c0b85d746e66a55f44f5df99432171).
- remove `runtime-unprivileged` image as per upstream's [pull/3237](https://github.com/knative/serving/commit/aa48603716c0b85d746e66a55f44f5df99432171)..