### PR TITLE
Move binaries into the same location as ko would to be compatible.

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD ${bin} /usr/bin/${bin}
-ENTRYPOINT ["/usr/bin/${bin}"]
+ADD ${bin} /ko-app/${bin}
+ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD activator /usr/bin/activator
-ENTRYPOINT ["/usr/bin/activator"]
+ADD activator /ko-app/activator
+ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD autoscaler /usr/bin/autoscaler
-ENTRYPOINT ["/usr/bin/autoscaler"]
+ADD autoscaler /ko-app/autoscaler
+ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/ci-operator/knative-images/certmanager/Dockerfile
+++ b/openshift/ci-operator/knative-images/certmanager/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD certmanager /usr/bin/certmanager
-ENTRYPOINT ["/usr/bin/certmanager"]
+ADD certmanager /ko-app/certmanager
+ENTRYPOINT ["/ko-app/certmanager"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD controller /usr/bin/controller
-ENTRYPOINT ["/usr/bin/controller"]
+ADD controller /ko-app/controller
+ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD istio /usr/bin/istio
-ENTRYPOINT ["/usr/bin/istio"]
+ADD istio /ko-app/istio
+ENTRYPOINT ["/ko-app/istio"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD queue /usr/bin/queue
-ENTRYPOINT ["/usr/bin/queue"]
+ADD queue /ko-app/queue
+ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD webhook /usr/bin/webhook
-ENTRYPOINT ["/usr/bin/webhook"]
+ADD webhook /ko-app/webhook
+ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD autoscale /usr/bin/autoscale
-ENTRYPOINT ["/usr/bin/autoscale"]
+ADD autoscale /ko-app/autoscale
+ENTRYPOINT ["/ko-app/autoscale"]

--- a/openshift/ci-operator/knative-test-images/bloatingcow/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/bloatingcow/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD bloatingcow /usr/bin/bloatingcow
-ENTRYPOINT ["/usr/bin/bloatingcow"]
+ADD bloatingcow /ko-app/bloatingcow
+ENTRYPOINT ["/ko-app/bloatingcow"]

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD failing /usr/bin/failing
-ENTRYPOINT ["/usr/bin/failing"]
+ADD failing /ko-app/failing
+ENTRYPOINT ["/ko-app/failing"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD grpc-ping /usr/bin/grpc-ping
-ENTRYPOINT ["/usr/bin/grpc-ping"]
+ADD grpc-ping /ko-app/grpc-ping
+ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD hellovolume /usr/bin/hellovolume
-ENTRYPOINT ["/usr/bin/hellovolume"]
+ADD hellovolume /ko-app/hellovolume
+ENTRYPOINT ["/ko-app/hellovolume"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD helloworld /usr/bin/helloworld
-ENTRYPOINT ["/usr/bin/helloworld"]
+ADD helloworld /ko-app/helloworld
+ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD httpproxy /usr/bin/httpproxy
-ENTRYPOINT ["/usr/bin/httpproxy"]
+ADD httpproxy /ko-app/httpproxy
+ENTRYPOINT ["/ko-app/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD observed-concurrency /usr/bin/observed-concurrency
-ENTRYPOINT ["/usr/bin/observed-concurrency"]
+ADD observed-concurrency /ko-app/observed-concurrency
+ENTRYPOINT ["/ko-app/observed-concurrency"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD pizzaplanetv1 /usr/bin/pizzaplanetv1
-ENTRYPOINT ["/usr/bin/pizzaplanetv1"]
+ADD pizzaplanetv1 /ko-app/pizzaplanetv1
+ENTRYPOINT ["/ko-app/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD pizzaplanetv2 /usr/bin/pizzaplanetv2
-ENTRYPOINT ["/usr/bin/pizzaplanetv2"]
+ADD pizzaplanetv2 /ko-app/pizzaplanetv2
+ENTRYPOINT ["/ko-app/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/printport/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/printport/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD printport /usr/bin/printport
-ENTRYPOINT ["/usr/bin/printport"]
+ADD printport /ko-app/printport
+ENTRYPOINT ["/ko-app/printport"]

--- a/openshift/ci-operator/knative-test-images/protocols/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/protocols/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD protocols /usr/bin/protocols
-ENTRYPOINT ["/usr/bin/protocols"]
+ADD protocols /ko-app/protocols
+ENTRYPOINT ["/ko-app/protocols"]

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD runtime /usr/bin/runtime
-ENTRYPOINT ["/usr/bin/runtime"]
+ADD runtime /ko-app/runtime
+ENTRYPOINT ["/ko-app/runtime"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD singlethreaded /usr/bin/singlethreaded
-ENTRYPOINT ["/usr/bin/singlethreaded"]
+ADD singlethreaded /ko-app/singlethreaded
+ENTRYPOINT ["/ko-app/singlethreaded"]

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD timeout /usr/bin/timeout
-ENTRYPOINT ["/usr/bin/timeout"]
+ADD timeout /ko-app/timeout
+ENTRYPOINT ["/ko-app/timeout"]

--- a/openshift/ci-operator/knative-test-images/workingdir/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/workingdir/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD workingdir /usr/bin/workingdir
-ENTRYPOINT ["/usr/bin/workingdir"]
+ADD workingdir /ko-app/workingdir
+ENTRYPOINT ["/ko-app/workingdir"]

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -2,5 +2,5 @@
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 USER 65532
 
-ADD wsserver /usr/bin/wsserver
-ENTRYPOINT ["/usr/bin/wsserver"]
+ADD wsserver /ko-app/wsserver
+ENTRYPOINT ["/ko-app/wsserver"]


### PR DESCRIPTION
The queue-proxy now tries to reuse that binary to run processes. Moving them all into the same location to avoid confusion with `ko` built images.