### PR TITLE
Resolve only v1alpha1 CRDs until we're on OpenShift 4.2.

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -205,7 +205,14 @@ function run_e2e_tests(){
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -parallel=1 \
-    ./test/conformance/... \
+    ./test/conformance/runtime/... \
+    --kubeconfig $KUBECONFIG \
+    --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \
+    ${options} || failed=1
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -parallel=1 \
+    ./test/conformance/api/v1alpha1/... \
     --kubeconfig $KUBECONFIG \
     --dockerrepo ${INTERNAL_REGISTRY}/${SERVING_NAMESPACE} \
     ${options} || failed=1

--- a/openshift/patches/002-v1beta1.patch
+++ b/openshift/patches/002-v1beta1.patch
@@ -1,0 +1,12 @@
+diff --git a/test/e2e/v1beta1_test.go b/test/e2e/v1beta1_test.go
+index aa538b91..3891cad1 100644
+--- a/test/e2e/v1beta1_test.go
++++ b/test/e2e/v1beta1_test.go
+@@ -33,6 +33,7 @@ import (
+ )
+ 
+ func TestV1beta1Translation(t *testing.T) {
++	t.Skip("v1beta1 API is not yet available")
+ 	t.Parallel()
+ 	cancel := logstream.Start(t)
+ 	defer cancel()

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,7 +5,7 @@ source $(dirname $0)/resolve.sh
 release=$1
 output_file="openshift/release/knative-serving-${release}.yaml"
 
-if [ $release = "ci" ]; then
+if [ "$release" = "ci" ]; then
     image_prefix="image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-"
     tag=""
 else
@@ -13,4 +13,9 @@ else
     tag=$release
 fi
 
-resolve_resources config/ $output_file $image_prefix $tag
+resolve_resources config/ "$output_file" "$image_prefix" "$tag"
+
+# append v1alpha1 CRD definitions
+for yaml in config/v1alpha1/*.yaml; do
+    resolve_file "$yaml" "$output_file" "$image_prefix" "$tag"
+done

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -10,20 +10,29 @@ function resolve_resources(){
 
   echo "Writing resolved yaml to $resolved_file_name"
 
-  > $resolved_file_name
+  > "$resolved_file_name"
 
   for yaml in "$dir"/*.yaml; do
-    echo "---" >> $resolved_file_name
-    # 1. Prefix test image references with test-
-    # 2. Rewrite image references
-    # 3. Update config map entry
-    # 4. Remove comment lines
-    # 5. Remove empty lines
-    sed -e "s+\(.* image: \)\(github.com\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
-        -e "s+\(.* image: \)\(github.com\)\(.*/\)\(.*\)+\1 ${image_prefix}\4${image_tag}+g" \
-        -e "s+\(.* queueSidecarImage: \)\(github.com\)\(.*/\)\(.*\)+\1 ${image_prefix}\4${image_tag}+g" \
-        -e '/^[ \t]*#/d' \
-        -e '/^[ \t]*$/d' \
-        "$yaml" >> $resolved_file_name
+    resolve_file "$yaml" "$resolved_file_name" "$image_prefix" "$image_tag"
   done
+}
+
+function resolve_file() {
+  local file=$1
+  local to=$2
+  local image_prefix=$3
+  local image_tag=$4
+
+  echo "---" >> "$to"
+  # 1. Prefix test image references with test-
+  # 2. Rewrite image references
+  # 3. Update config map entry
+  # 4. Remove comment lines
+  # 5. Remove empty lines
+  sed -e "s+\(.* image: \)\(github.com\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
+      -e "s+\(.* image: \)\(github.com\)\(.*/\)\(.*\)+\1 ${image_prefix}\4${image_tag}+g" \
+      -e "s+\(.* queueSidecarImage: \)\(github.com\)\(.*/\)\(.*\)+\1 ${image_prefix}\4${image_tag}+g" \
+      -e '/^[ \t]*#/d' \
+      -e '/^[ \t]*$/d' \
+      "$file" >> "$to"
 }


### PR DESCRIPTION
Due to the bug discovered in CRDs, we'll run on v1alpha1 only for now. We can change this anytime, these changes should get CI green again though.