### PR TITLE
Add format check of new branch name to pass for create-release-branch.sh

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,9 +1,15 @@
-#!/bin/bash
+#!/bin/bash -e
 
-# Usage: create-release-branch.sh v0.4.1 release-0.4
+# Usage: create-release-branch.sh v0.4.1 release-v0.4.1
 
 release=$1
 target=$2
+release_regexp="^release-v([0-9]\.)+([0-9])$"
+
+if [[ ! $release =~ $release_re ]]; then
+    echo "\"$release\" is wrong format. Must have proper format like release-v0.1.2"
+    exit 1
+fi
 
 # Fetch the latest tags and checkout a new branch from the wanted tag.
 git fetch upstream --tags


### PR DESCRIPTION
New branch must have `release-vN.N.N` format.

This patch changes to:
- add an format check in create-release-branch.sh.
- add `-e` option to stop script when it failed in the middle of script.