### PR TITLE
Remove some Dockerfile

### DIFF
--- a/openshift/ci-operator/knative-test-images/bloatingcow/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/bloatingcow/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
-
-ADD bloatingcow /ko-app/bloatingcow
-ENTRYPOINT ["/ko-app/bloatingcow"]

--- a/openshift/ci-operator/knative-test-images/printport/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/printport/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
-
-ADD printport /ko-app/printport
-ENTRYPOINT ["/ko-app/printport"]

--- a/openshift/ci-operator/knative-test-images/protocols/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/protocols/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
-
-ADD protocols /ko-app/protocols
-ENTRYPOINT ["/ko-app/protocols"]

--- a/openshift/ci-operator/knative-test-images/workingdir/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/workingdir/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
-
-ADD workingdir /ko-app/workingdir
-ENTRYPOINT ["/ko-app/workingdir"]


### PR DESCRIPTION
This patch changes removes following images' Dockerfiles.
- protocols
- workingdir
- bloatingcow
- printport

ci-operator has already had the change as https://github.com/openshift/release/pull/4353

cc @markusthoemmes 