### PR TITLE
Replace canonical_go_repository github.com/knative/serving with knative.dev/serving

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -18,7 +18,7 @@ base_images:
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
-canonical_go_repository: github.com/knative/serving
+canonical_go_repository: knative.dev/serving
 binary_build_commands: make install
 test_binary_build_commands: make test-install
 tests:


### PR DESCRIPTION
Since upstream migrated to `knative.dev/serving`, this patch also
changes ci-operator config to knative.dev/serving from
github.com/knative/serving.

ref:
- upstream: https://github.com/knative/serving/commit/303602bd6b7a4ebac0f2d13dbbcd815a98153b67
- openshift/release : https://github.com/openshift/release/pull/4372