### PR TITLE
Update route retry patch

### DIFF
--- a/openshift/patches/003-routeretry.patch
+++ b/openshift/patches/003-routeretry.patch
@@ -1,32 +1,52 @@
 diff --git a/test/v1alpha1/route.go b/test/v1alpha1/route.go
-index 7622aacc..6328421d 100644
+index c1c4cb12..fb118745 100644
 --- a/test/v1alpha1/route.go
 +++ b/test/v1alpha1/route.go
-@@ -72,9 +72,10 @@ func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames,
+@@ -21,6 +21,7 @@ package v1alpha1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 	"testing"
+ 
+ 	"github.com/davecgh/go-spew/spew"
+@@ -70,8 +71,13 @@ func CreateRoute(t *testing.T, clients *test.Clients, names test.ResourceNames,
+ }
  
  // RetryingRouteInconsistency retries common requests seen when creating a new route
- // - 404 until the route is propagated to the proxy
++// - 404 until the route is propagated to the proxy
 +// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
  func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
  	return func(resp *spoof.Response) (bool, error) {
--		if resp.StatusCode == http.StatusNotFound {
 +		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
- 			return false, nil
- 		}
- 
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}
 diff --git a/test/v1beta1/route.go b/test/v1beta1/route.go
-index 3fc5e825..54068dad 100644
+index 663f1728..29594507 100644
 --- a/test/v1beta1/route.go
 +++ b/test/v1beta1/route.go
-@@ -112,9 +112,10 @@ func IsRouteReady(r *v1beta1.Route) (bool, error) {
+@@ -19,6 +19,7 @@ package v1beta1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 	"testing"
+ 
+ 	"github.com/davecgh/go-spew/spew"
+@@ -116,8 +117,13 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
+ }
  
  // RetryingRouteInconsistency retries common requests seen when creating a new route
- // - 404 until the route is propagated to the proxy
++// - 404 until the route is propagated to the proxy
 +// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
  func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
  	return func(resp *spoof.Response) (bool, error) {
--		if resp.StatusCode == http.StatusNotFound {
 +		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
- 			return false, nil
- 		}
- 
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}


### PR DESCRIPTION
As per title. As disccused on Slack, we keep both 404s and 503s error exceptions for now.

cc @markusthoemmes 