### PR TITLE
Move olm namespace to openshift-marketplace after OpenShift 4.2

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -15,9 +15,14 @@ readonly TEST_NAMESPACE=serving-tests
 readonly TEST_NAMESPACE_ALT=serving-tests-alt
 readonly SERVING_NAMESPACE=knative-serving
 readonly TARGET_IMAGE_PREFIX="$INTERNAL_REGISTRY/$SERVING_NAMESPACE/knative-serving-"
-# TODO: Subscription.spec.sourceNamespace does not work on OCP v4.2. Need to revert after https://jira.coreos.com/browse/OLM-1190 is solved.
-readonly OLM_NAMESPACE="knative-serving"
-#readonly OLM_NAMESPACE="openshift-operator-lifecycle-manager"
+
+# The OLM global namespace was moved to openshift-marketplace since v4.2
+# ref: https://jira.coreos.com/browse/OLM-1190
+if [ ${HOSTNAME} = "e2e-aws-ocp-41" ]; then
+  readonly OLM_NAMESPACE="openshift-operator-lifecycle-manager"
+else
+  readonly OLM_NAMESPACE="openshift-marketplace"
+fi
 
 env
 


### PR DESCRIPTION
OLM used same namespace with Subscription for a workaround since
`openshift-operator-lifecycle-manager` namespace stopped working after
4.2.

But according to https://jira.coreos.com/browse/OLM-1190, it turned out
that the global namespace moved from
`openshift-operator-lifecycle-manager` to `openshift-marketplace`.

Hence, this patch changes to let OLM use ns
openshift-operator-lifecycle-manager for 4.1 and openshift-marketplace
for 4.2 or later.

Verified with https://github.com/openshift/knative-serving/pull/217 (tests failed but it is due to different issues.)

cc @markusthoemmes 