### PR TITLE
Update grpc patch to test without resolvabledomain option

### DIFF
--- a/openshift/patches/004-grpc.patch
+++ b/openshift/patches/004-grpc.patch
@@ -1,12 +1,15 @@
 diff --git a/test/e2e/grpc_test.go b/test/e2e/grpc_test.go
-index f43da5af..ca0b8814 100644
+index 3a7c9e4a..0466bb54 100644
 --- a/test/e2e/grpc_test.go
 +++ b/test/e2e/grpc_test.go
-@@ -157,6 +157,7 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
- }
+@@ -157,6 +157,10 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
  
  func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
-+	t.Skip("gRPC doesn't work with OCP Routes")
  	t.Helper()
++	if test.ServingFlags.ResolvableDomain {
++		test.ServingFlags.ResolvableDomain = false
++		defer func() { test.ServingFlags.ResolvableDomain = true }()
++	}
  	t.Parallel()
  	cancel := logstream.Start(t)
+ 	defer cancel()


### PR DESCRIPTION
There are two ways to use gRPC with Knative on OpenShift.

- TLS+SNI & Passthrough to OpenShift Route.
- HTTP(s) directory to ingress.

Since using ingress directory would be more common usage for gRPC, this patch
let gRPC e2e tests run without resolvabledomain option.