### PR TITLE
Disable HPA autoscaling test.

### DIFF
--- a/openshift/patches/005-disablehpa.patch
+++ b/openshift/patches/005-disablehpa.patch
@@ -1,0 +1,12 @@
+diff --git a/test/e2e/autoscale_test.go b/test/e2e/autoscale_test.go
+index 6e94b7a0..7acd3f0e 100644
+--- a/test/e2e/autoscale_test.go
++++ b/test/e2e/autoscale_test.go
+@@ -315,7 +315,6 @@ func TestAutoscaleUpCountPods(t *testing.T) {
+ 	t.Parallel()
+ 
+ 	classes := map[string]string{
+-		"hpa": autoscaling.HPA,
+ 		"kpa": autoscaling.KPA,
+ 	}
+ 


### PR DESCRIPTION
Ref: SRVKS-186

Disabling this test for now as we also disabled the custom-metrics API so it'll always break.