### PR TITLE
Add nscert image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio ./cmd/networking/certmanager
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio ./cmd/networking/certmanager ./cmd/networking/nscert
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
 
 install:

--- a/openshift/ci-operator/knative-images/nscert/Dockerfile
+++ b/openshift/ci-operator/knative-images/nscert/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+USER 65532
+
+ADD nscert /ko-app/nscert
+ENTRYPOINT ["/ko-app/nscert"]


### PR DESCRIPTION
This patch adds nscert image.

Please also refer to https://github.com/openshift/release/pull/4956 and https://github.com/knative/serving/commit/2bcb6291efead25aa00c95f3a3828790f5ea2d8a