### PR TITLE
Remove API specification from generate-release script.

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -14,8 +14,3 @@ else
 fi
 
 resolve_resources config/ "$output_file" "$image_prefix" "$tag"
-
-# append v1alpha1 CRD definitions
-for yaml in config/v1alpha1/*.yaml; do
-    resolve_file "$yaml" "$output_file" "$image_prefix" "$tag"
-done


### PR DESCRIPTION
As per https://github.com/knative/serving/commit/77b0043e5cee4981738b7dfe226a72e4402309c7, the configuration is no longer split.