### PR TITLE
Run upstream rolling upgrade tests

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -5,6 +5,7 @@ source $(dirname $0)/release/resolve.sh
 
 set -x
 
+readonly UPGRADE_FROM_CSV=serverless-operator.v1.0.0 # Previous CSV version from which we upgrade to latest
 readonly K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
 readonly API_SERVER=$(oc config view --minify | grep server | awk -F'//' '{print $2}' | awk -F':' '{print $1}')
 readonly INTERNAL_REGISTRY="${INTERNAL_REGISTRY:-"image-registry.openshift-image-registry.svc:5000"}"
@@ -184,7 +185,27 @@ spec:
   sourceNamespace: $OLM_NAMESPACE
   name: ${NAME}
   channel: techpreview
+  installPlanApproval: Manual
+  startingCSV: ${UPGRADE_FROM_CSV}
 EOF
+
+  # Approve the initial installplan automatically 
+  approve_csv $UPGRADE_FROM_CSV
+}
+
+function approve_csv(){
+  local csv_version=$1
+
+  # Wait for the installplan to be available
+  timeout 300 "[[ \$(oc get InstallPlan -n $SERVING_NAMESPACE | grep -c $csv_version) -eq 0 ]]" || return 1
+
+  local install_plan=$(oc get InstallPlan -n $SERVING_NAMESPACE | grep $csv_version | awk '{ print $1}')
+  oc get InstallPlan $install_plan -n $SERVING_NAMESPACE -o yaml | sed 's/\(.*approved:\) false/\1 true/' | oc replace -f -
+  
+  # Wait for the installedCSV to be the new one
+  timeout 300 "[[ \$(oc get Subscription -n $SERVING_NAMESPACE -o jsonpath='{.items[0].status.installedCSV}' | grep -c $csv_version) -eq 0 ]]" || return 1
+
+  timeout 300 "[[ \$(oc get ClusterServiceVersion $csv_version -n $SERVING_NAMESPACE -o jsonpath='{.status.phase}') != Succeeded ]]" || return 1
 }
 
 function tag_core_images(){
@@ -207,6 +228,9 @@ function create_test_resources_openshift() {
   tag_core_images tests-resolved.yaml
 
   oc apply -f tests-resolved.yaml
+
+  # Delete redundant job - default domains not used
+  oc delete job default-domain -n $SERVING_NAMESPACE
 
   echo ">> Ensuring pods in test namespaces can access test images"
   oc policy add-role-to-group system:image-puller system:serviceaccounts:${TEST_NAMESPACE} --namespace=${SERVING_NAMESPACE}
@@ -252,6 +276,63 @@ function run_e2e_tests(){
     --resolvabledomain || failed=1
 
   return $failed
+}
+
+function serving_pods_newer_than_csv(){
+  local csv=$1
+  local pod_timestamps="$(oc get pods -n $SERVING_NAMESPACE -l name!=knative-openshift-ingress,name!=knative-serving-operator -o jsonpath='{.items[*].metadata.creationTimestamp}')"
+  local csv_succeeded_timestamp=$(oc get clusterserviceversion $csv -n $SERVING_NAMESPACE -o=jsonpath='{.status.conditions[?(@.phase=="Succeeded")].lastUpdateTime}')
+  csv_succeeded_timestamp=$(date -d $csv_succeeded_timestamp +%s)
+
+  # If any pod is older than the CSV timestamp return False
+  for t in $pod_timestamps; do
+    [[ $(date -d $t +%s) -le $csv_succeeded_timestamp ]] && echo "False" && return 1
+  done
+  
+  echo "True"
+}
+
+function run_rolling_upgrade_tests() {
+    header "Running rolling upgrade tests"
+    
+    local TIMEOUT_TESTS="20m"
+    failed=0
+
+    report_go_test -tags=preupgrade -timeout=${TIMEOUT_TESTS} ./test/upgrade \
+    --dockerrepo "${INTERNAL_REGISTRY}/${SERVING_NAMESPACE}" \
+    --kubeconfig $KUBECONFIG || failed=1
+
+    echo "Starting prober test"
+
+    # Make prober send requests more often compared with upstream where it is 1/second
+    sed -e 's/\(.*requestInterval =\).*/\1 200 * time.Millisecond/' -i vendor/knative.dev/pkg/test/spoof/spoof.go
+
+    rm -f /tmp/prober-signal
+    report_go_test -tags=probe -timeout=${TIMEOUT_TESTS} ./test/upgrade \
+    --dockerrepo "${INTERNAL_REGISTRY}/${SERVING_NAMESPACE}" \
+    --kubeconfig $KUBECONFIG &
+
+    PROBER_PID=$!
+    echo "Prober PID is ${PROBER_PID}"
+
+    local latest_csv=$(oc get configmaps serverless-operator -n $OLM_NAMESPACE -o jsonpath='{.data.packages}' | grep currentCSV | awk '{print $2}')
+    
+    approve_csv $latest_csv || failed=1
+    
+    # Wait for all Knative Serving pods to be upgraded
+    timeout 300 "[[ \$(serving_pods_newer_than_csv $latest_csv) != True ]]" || return 1
+
+    echo "Running postupgrade tests"
+    report_go_test -tags=postupgrade -timeout=${TIMEOUT_TESTS} ./test/upgrade \
+    --dockerrepo "${INTERNAL_REGISTRY}/${SERVING_NAMESPACE}" \
+    --kubeconfig $KUBECONFIG || failed=1
+
+    echo "done" > /tmp/prober-signal
+
+    echo "Waiting for prober test"
+    wait ${PROBER_PID}
+
+    return $failed
 }
 
 function delete_knative_openshift() {
@@ -326,6 +407,9 @@ failed=0
 (( !failed )) && install_knative || failed=1
 
 (( !failed )) && create_test_resources_openshift || failed=1
+
+# Rolling upgrade must be run before E2E tests because they upgrade to the latest version
+(( !failed )) && run_rolling_upgrade_tests || failed=1
 
 (( !failed )) && run_e2e_tests || failed=1
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -202,15 +202,15 @@ function approve_csv(){
   local csv_version=$1
 
   # Wait for the installplan to be available
-  timeout 300 "[[ \$(oc get InstallPlan -n $SERVING_NAMESPACE | grep -c $csv_version) -eq 0 ]]" || return 1
+  timeout 300 '[[ $(oc get InstallPlan -n $SERVING_NAMESPACE | grep -c $csv_version) -eq 0 ]]' || return 1
 
   local install_plan=$(oc get InstallPlan -n $SERVING_NAMESPACE | grep $csv_version | awk '{ print $1}')
   oc get InstallPlan $install_plan -n $SERVING_NAMESPACE -o yaml | sed 's/\(.*approved:\) false/\1 true/' | oc replace -f -
   
   # Wait for the installedCSV to be the new one
-  timeout 300 "[[ \$(oc get Subscription -n $SERVING_NAMESPACE -o jsonpath='{.items[0].status.installedCSV}' | grep -c $csv_version) -eq 0 ]]" || return 1
+  timeout 300 '[[ $(oc get Subscription -n $SERVING_NAMESPACE -o jsonpath="{.items[0].status.installedCSV}" | grep -c $csv_version) -eq 0 ]]' || return 1
 
-  timeout 300 "[[ \$(oc get ClusterServiceVersion $csv_version -n $SERVING_NAMESPACE -o jsonpath='{.status.phase}') != Succeeded ]]" || return 1
+  timeout 300 '[[ $(oc get ClusterServiceVersion $csv_version -n $SERVING_NAMESPACE -o jsonpath="{.status.phase}") != Succeeded ]]' || return 1
 }
 
 function tag_core_images(){

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -152,19 +152,13 @@ data:
           - Routing and network programming for Istio components
           - Point-in-time snapshots of deployed code and configurations
 
-          ## Prerequisites
-
-          ### Istio
-
-          Knative requires Istio. A minimal Maistra ControlPlane can be
-          installed using the Maistra operator.
-
           ## Further Information
 
           For documentation on using Knative Serving, see the
-          [serving section](https://www.knative.dev/docs/serving/) of the
-          [Knative documentation site](https://www.knative.dev/docs).
-        displayName: Serverless Operator
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
         icon:
         - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
           mediatype: image/svg+xml
@@ -275,15 +269,304 @@ data:
                       - name: OPERATOR_NAME
                         value: knative-serving-operator
                       - name: IMAGE_QUEUE
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.7.1
+                      - name: IMAGE_activator
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.7.1
+                      - name: IMAGE_autoscaler
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.7.1
+                      - name: IMAGE_controller
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.7.1
+                      - name: IMAGE_networking-certmanager
+                        value: quay.io/openshift-knative/knative-serving-certmanager:v0.7.1
+                      - name: IMAGE_networking-istio
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.7.1
+                      - name: IMAGE_webhook
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.7.1
+                      image: quay.io/openshift-knative/knative-serving-operator:v0.7.1-TP1-04
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.7
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: knative@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        version: 1.0.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"serving.knative.dev/v1alpha1","kind":"KnativeServing","metadata":{"name":"knative-serving"},"spec":{"config":{"autoscaler":{"container-concurrency-target-default":"100","container-concurrency-target-percentage":"1.0","enable-scale-to-zero":"true","max-scale-up-rate":"10","panic-threshold-percentage":"200.0","panic-window":"6s","panic-window-percentage":"10.0","scale-to-zero-grace-period":"30s","stable-window":"60s","tick-interval":"2s"},"defaults":{"revision-cpu-limit":"1000m","revision-cpu-request":"400m","revision-memory-limit":"200M","revision-memory-request":"100M","revision-timeout-seconds":"300"},"deployment":{"registriesSkippingTagResolving":"ko.local,dev.local"},"gc":{"stale-revision-create-delay":"24h","stale-revision-lastpinned-debounce":"5h","stale-revision-minimum-generations":"1","stale-revision-timeout":"15h"},"logging":{"loglevel.activator":"info","loglevel.autoscaler":"info","loglevel.controller":"info","loglevel.queueproxy":"info","loglevel.webhook":"info"},"observability":{"logging.enable-var-log-collection":"false","metrics.backend-destination":"prometheus"},"tracing":{"enable":"false","sample-rate":"0.1"}}}}]'
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.1.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat
+        name: serverless-operator.v1.1.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        description: |
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
                         value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-queue
                       - name: IMAGE_activator
                         value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-activator
                       - name: IMAGE_autoscaler
                         value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-autoscaler
+                      - name: IMAGE_autoscaler-hpa
+                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-autoscaler-hpa
                       - name: IMAGE_controller
                         value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-controller
-                      - name: IMAGE_networking-certmanager
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-certmanager
                       - name: IMAGE_networking-istio
                         value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-istio
                       - name: IMAGE_webhook
@@ -386,9 +669,11 @@ data:
         - FaaS
         - microservices
         - scale to zero
+        - knative
+        - serving
         links:
         - name: Documentation
-          url: https://developers.redhat.com/topics/serverless-architecture/
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
         - name: Source Repository
           url: https://github.com/openshift-knative/serverless-operator
         maintainers:
@@ -397,12 +682,13 @@ data:
         maturity: alpha
         provider:
           name: Red Hat
-        version: 1.0.0
+        replaces: serverless-operator.v1.0.0
+        version: 1.1.0
   packages: |-
     - packageName: serverless-operator
       channels:
       - name: techpreview
-        currentCSV: serverless-operator.v1.0.0
+        currentCSV: serverless-operator.v1.1.0
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource


### PR DESCRIPTION
Please review and let me know if this approach is acceptable. 
I used best effort to create the serverless-operator.v1.1.0 CSV.

Another option would be to run these tests in a separate target for OpenShift CI. There would be also rolling-upgrade-aws in addition to the existing e2e-aws.