### PR TITLE
Fix productized build with change to WORKDIR

### DIFF
--- a/openshift/productization/dist-git/Dockerfile.activator
+++ b/openshift/productization/dist-git/Dockerfile.activator
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/activator ./cmd/activator
 

--- a/openshift/productization/dist-git/Dockerfile.autoscaler
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/autoscaler ./cmd/autoscaler
 

--- a/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/autoscaler-hpa ./cmd/autoscaler-hpa
 

--- a/openshift/productization/dist-git/Dockerfile.controller
+++ b/openshift/productization/dist-git/Dockerfile.controller
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/controller ./cmd/controller
 

--- a/openshift/productization/dist-git/Dockerfile.networking-istio
+++ b/openshift/productization/dist-git/Dockerfile.networking-istio
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/networking-istio ./cmd/networking/istio
 

--- a/openshift/productization/dist-git/Dockerfile.queue
+++ b/openshift/productization/dist-git/Dockerfile.queue
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/queue ./cmd/queue
 

--- a/openshift/productization/dist-git/Dockerfile.webhook
+++ b/openshift/productization/dist-git/Dockerfile.webhook
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/webhook ./cmd/webhook
 

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -1,5 +1,5 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
-WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
 RUN go build -o /tmp/$SUBCOMPONENT ./cmd/$GO_PACKAGE
 


### PR DESCRIPTION
This fix solves the following compile error:

```
$ go build -o /tmp/activator ./cmd/activator
cmd/activator/main.go:52:2: cannot find package "knative.dev/serving/pkg/activator" in any of:
	/opt/app-root/src/go/src/github.com/knative/serving/vendor/knative.dev/serving/pkg/activator (vendor tree)
	/usr/lib/golang/src/knative.dev/serving/pkg/activator (from $GOROOT)
	/opt/app-root/src/go/src/knative.dev/serving/pkg/activator (from $GOPATH)
...
```