### PR TITLE
Build our binaries with Golang 1.13.

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.12
+FROM openshift/origin-release:golang-1.13
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
As per title. Knative needs 1.13 post 0.9.