### PR TITLE
Make sure productization images look like ko built images.

### DIFF
--- a/openshift/productization/dist-git/Dockerfile.activator
+++ b/openshift/productization/dist-git/Dockerfile.activator
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/activator ./cmd/activator
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/activator /usr/bin/activator
+COPY --from=builder /tmp/activator /ko-app/activator
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-activator-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Activator" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Activator"
 
-ENTRYPOINT ["/usr/bin/activator"]
+ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/productization/dist-git/Dockerfile.autoscaler
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/autoscaler ./cmd/autoscaler
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/autoscaler /usr/bin/autoscaler
+COPY --from=builder /tmp/autoscaler /ko-app/autoscaler
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-autoscaler-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler"
 
-ENTRYPOINT ["/usr/bin/autoscaler"]
+ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/autoscaler-hpa ./cmd/autoscaler-hpa
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/autoscaler-hpa /usr/bin/autoscaler-hpa
+COPY --from=builder /tmp/autoscaler-hpa /ko-app/autoscaler-hpa
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-autoscaler-hpa-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA"
 
-ENTRYPOINT ["/usr/bin/autoscaler-hpa"]
+ENTRYPOINT ["/ko-app/autoscaler-hpa"]

--- a/openshift/productization/dist-git/Dockerfile.controller
+++ b/openshift/productization/dist-git/Dockerfile.controller
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/controller ./cmd/controller
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/controller /usr/bin/controller
+COPY --from=builder /tmp/controller /ko-app/controller
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-controller-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Controller" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Controller"
 
-ENTRYPOINT ["/usr/bin/controller"]
+ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/productization/dist-git/Dockerfile.networking-istio
+++ b/openshift/productization/dist-git/Dockerfile.networking-istio
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/networking-istio ./cmd/networking/istio
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/networking-istio /usr/bin/networking-istio
+COPY --from=builder /tmp/networking-istio /ko-app/networking-istio
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-istio-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking Istio"
 
-ENTRYPOINT ["/usr/bin/networking-istio"]
+ENTRYPOINT ["/ko-app/networking-istio"]

--- a/openshift/productization/dist-git/Dockerfile.queue
+++ b/openshift/productization/dist-git/Dockerfile.queue
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/queue ./cmd/queue
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/queue /usr/bin/queue
+COPY --from=builder /tmp/queue /ko-app/queue
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-queue-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Queue" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Queue"
 
-ENTRYPOINT ["/usr/bin/queue"]
+ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/productization/dist-git/Dockerfile.webhook
+++ b/openshift/productization/dist-git/Dockerfile.webhook
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/webhook ./cmd/webhook
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/webhook /usr/bin/webhook
+COPY --from=builder /tmp/webhook /ko-app/webhook
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-webhook-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving Webhook" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Webhook"
 
-ENTRYPOINT ["/usr/bin/webhook"]
+ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -4,7 +4,7 @@ COPY . .
 RUN go build -o /tmp/$SUBCOMPONENT ./cmd/$GO_PACKAGE
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/$SUBCOMPONENT /usr/bin/$SUBCOMPONENT
+COPY --from=builder /tmp/$SUBCOMPONENT /ko-app/$SUBCOMPONENT
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-$SUBCOMPONENT-rhel8-container" \
@@ -15,4 +15,4 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Serving $CAPITALIZED_SUBCOMPONENT" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving $CAPITALIZED_SUBCOMPONENT"
 
-ENTRYPOINT ["/usr/bin/$SUBCOMPONENT"]
+ENTRYPOINT ["/ko-app/$SUBCOMPONENT"]


### PR DESCRIPTION
v0.8.x added a different mechanism to run readiness probes in Knative. It uses the queue-proxy binary to run an exec probe on itself.

The images therefore need to like as if they were built by ko, which means the binaries need to be in `/ko-app/$SUBCOMPONENT`.