### PR TITLE
Expand 005-disablehpa.patch to skip hpa test for TestAutoscaleUpCountPods

### DIFF
--- a/openshift/patches/005-disablehpa.patch
+++ b/openshift/patches/005-disablehpa.patch
@@ -1,8 +1,16 @@
 diff --git a/test/e2e/autoscale_test.go b/test/e2e/autoscale_test.go
-index 6e94b7a0..7acd3f0e 100644
+index e385327ad..2b8edccd6 100644
 --- a/test/e2e/autoscale_test.go
 +++ b/test/e2e/autoscale_test.go
-@@ -315,7 +315,6 @@ func TestAutoscaleUpCountPods(t *testing.T) {
+@@ -366,7 +366,6 @@ func TestAutoscaleUpCountPods(t *testing.T) {
+ 	t.Parallel()
+ 
+ 	classes := map[string]string{
+-		"hpa": autoscaling.HPA,
+ 		"kpa": autoscaling.KPA,
+ 	}
+ 
+@@ -399,7 +398,6 @@ func TestRPSBasedAutoscaleUpCountPods(t *testing.T) {
  	t.Parallel()
  
  	classes := map[string]string{


### PR DESCRIPTION
As per title, this patch skips hpa for TestAutoscaleUpCountPods.

cc @markusthoemmes 