### PR TITLE
Allow specifying the type of istio-ingressgateway service

### DIFF
--- a/openshift/servicemesh/controlplane-install.yaml
+++ b/openshift/servicemesh/controlplane-install.yaml
@@ -17,7 +17,7 @@ spec:
     gateways:
       istio-ingressgateway:
         autoscaleEnabled: false
-        type: LoadBalancer
+        type: ${INGRESS_TYPE}
       istio-egressgateway:
         enabled: false
       cluster-local-gateway:


### PR DESCRIPTION
Replaces https://github.com/openshift/knative-serving/pull/293 . My goal is to keep current behaviour as default and be able to specify ClusterIP as the type. And later use this in tests on vSphere