### PR TITLE
Only locally override resolvable flag.

### DIFF
--- a/openshift/patches/004-grpc.patch
+++ b/openshift/patches/004-grpc.patch
@@ -1,15 +1,27 @@
 diff --git a/test/e2e/grpc_test.go b/test/e2e/grpc_test.go
-index 3a7c9e4a..0466bb54 100644
+index a358b354c..5676d6b66 100644
 --- a/test/e2e/grpc_test.go
 +++ b/test/e2e/grpc_test.go
-@@ -157,6 +157,10 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
- 
+@@ -152,6 +152,7 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
  func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
  	t.Helper()
-+	if test.ServingFlags.ResolvableDomain {
-+		test.ServingFlags.ResolvableDomain = false
-+		defer func() { test.ServingFlags.ResolvableDomain = true }()
-+	}
  	t.Parallel()
++	resolvable := false
  	cancel := logstream.Start(t)
  	defer cancel()
+ 
+@@ -181,12 +182,12 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
+ 		url,
+ 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+ 		"gRPCPingReadyToServe",
+-		test.ServingFlags.ResolvableDomain); err != nil {
++		resolvable); err != nil {
+ 		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
+ 	}
+ 
+ 	host := url.Host
+-	if !test.ServingFlags.ResolvableDomain {
++	if !resolvable {
+ 		host = pkgTest.Flags.IngressEndpoint
+ 		if pkgTest.Flags.IngressEndpoint == "" {
+ 			host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)


### PR DESCRIPTION
Having this in front of the Parallel() call caused this to affect other tests even if Parallel was set to 1. This test would execute until the Parallel() call and be blocked for execution itself then. All other tests that would've been run in the same batch but before this test in that batch would see a non-resolvable domain setting as well.

Using a local variable now to be double sure this doesn't happen again.