### PR TITLE
Update productization files for v0.9.0

### DIFF
--- a/openshift/productization/dist-git/Dockerfile.activator
+++ b/openshift/productization/dist-git/Dockerfile.activator
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/activator ./cmd/
+RUN go build -o /tmp/activator ./cmd/activator
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/activator /usr/bin/activator
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/activator /usr/bin/activator
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-activator-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-activator-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Activator" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Activator" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Activator"
 
 ENTRYPOINT ["/usr/bin/activator"]

--- a/openshift/productization/dist-git/Dockerfile.autoscaler
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/autoscaler ./cmd/
+RUN go build -o /tmp/autoscaler ./cmd/autoscaler
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/autoscaler /usr/bin/autoscaler
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/autoscaler /usr/bin/autoscaler
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-autoscaler-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-autoscaler-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler"
 
 ENTRYPOINT ["/usr/bin/autoscaler"]

--- a/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
@@ -1,0 +1,18 @@
+FROM rhel8/go-toolset:1.12.8 AS builder
+WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+COPY . .
+RUN go build -o /tmp/autoscaler-hpa ./cmd/autoscaler/hpa
+
+FROM ubi8:8-released
+COPY --from=builder /tmp/autoscaler-hpa /usr/bin/autoscaler-hpa
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-tech-preview-serving-autoscaler-hpa-rhel8-container" \
+      name="openshift-serverless-1-tech-preview/serving-autoscaler-hpa-rhel8" \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
+      maintainer="mthoemme@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA"
+
+ENTRYPOINT ["/usr/bin/autoscaler-hpa"]

--- a/openshift/productization/dist-git/Dockerfile.controller
+++ b/openshift/productization/dist-git/Dockerfile.controller
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/controller ./cmd/
+RUN go build -o /tmp/controller ./cmd/controller
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/controller /usr/bin/controller
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/controller /usr/bin/controller
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-controller-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-controller-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Controller" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Controller" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Controller"
 
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/productization/dist-git/Dockerfile.networking-certmanager
+++ b/openshift/productization/dist-git/Dockerfile.networking-certmanager
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/networking-certmanager ./cmd/
+RUN go build -o /tmp/networking-certmanager ./cmd/networking/certmanager
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/networking-certmanager /usr/bin/networking-certmanager
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/networking-certmanager /usr/bin/networking-certmanager
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-certmanager-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-networking-certmanager-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Networking Certmanager" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Networking Certmanager" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking Certmanager"
 
 ENTRYPOINT ["/usr/bin/networking-certmanager"]

--- a/openshift/productization/dist-git/Dockerfile.networking-istio
+++ b/openshift/productization/dist-git/Dockerfile.networking-istio
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/networking-istio ./cmd/
+RUN go build -o /tmp/networking-istio ./cmd/networking/istio
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/networking-istio /usr/bin/networking-istio
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/networking-istio /usr/bin/networking-istio
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-istio-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-networking-istio-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking Istio"
 
 ENTRYPOINT ["/usr/bin/networking-istio"]

--- a/openshift/productization/dist-git/Dockerfile.networking-nscert
+++ b/openshift/productization/dist-git/Dockerfile.networking-nscert
@@ -1,0 +1,18 @@
+FROM rhel8/go-toolset:1.12.8 AS builder
+WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
+COPY . .
+RUN go build -o /tmp/networking-nscert ./cmd/networking/nscert
+
+FROM ubi8:8-released
+COPY --from=builder /tmp/networking-nscert /usr/bin/networking-nscert
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-nscert-rhel8-container" \
+      name="openshift-serverless-1-tech-preview/serving-networking-nscert-rhel8" \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Networking NSCert" \
+      maintainer="mthoemme@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Serving Networking NSCert" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking NSCert"
+
+ENTRYPOINT ["/usr/bin/networking-nscert"]

--- a/openshift/productization/dist-git/Dockerfile.queue
+++ b/openshift/productization/dist-git/Dockerfile.queue
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/queue ./cmd/
+RUN go build -o /tmp/queue ./cmd/queue
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/queue /usr/bin/queue
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/queue /usr/bin/queue
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-queue-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-queue-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Queue" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Queue" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Queue"
 
 ENTRYPOINT ["/usr/bin/queue"]

--- a/openshift/productization/dist-git/Dockerfile.webhook
+++ b/openshift/productization/dist-git/Dockerfile.webhook
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.12.8 AS builder
 WORKDIR /opt/app-root/src/go/src/github.com/knative/serving
 COPY . .
-RUN go build -o /tmp/webhook ./cmd/
+RUN go build -o /tmp/webhook ./cmd/webhook
 
 FROM ubi8:8-released
 COPY --from=builder /tmp/webhook /usr/bin/webhook
@@ -9,10 +9,10 @@ COPY --from=builder /tmp/webhook /usr/bin/webhook
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-webhook-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-webhook-rhel8" \
-      version="0.7.1" \
-      summary="Red Hat OpenShift Serverless 1  " \
+      version="0.9.0" \
+      summary="Red Hat OpenShift Serverless 1 Serving Webhook" \
       maintainer="mthoemme@redhat.com" \
-      description="Red Hat OpenShift Serverless 1  " \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1  "
+      description="Red Hat OpenShift Serverless 1 Serving Webhook" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Webhook"
 
 ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -9,7 +9,7 @@ COPY --from=builder /tmp/$SUBCOMPONENT /usr/bin/$SUBCOMPONENT
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-$COMPONENT-$SUBCOMPONENT-rhel8-container" \
       name="openshift-serverless-1-tech-preview/$COMPONENT-$SUBCOMPONENT-rhel8" \
-      version="0.7.1" \
+      version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
       maintainer="mthoemme@redhat.com" \
       description="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \

--- a/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
+++ b/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
@@ -3,7 +3,7 @@
 target_dir=$1
 
 component=serving
-for subcomponent in controller autoscaler activator networking-istio networking-certmanager webhook queue; do
+for subcomponent in controller autoscaler autoscaler-hpa activator networking-istio networking-certmanager networking-nscert webhook queue; do
     CAPITALIZED_COMPONENT=$(echo -e "$component" | sed -r 's/\<./\U&/g') \
     CAPITALIZED_SUBCOMPONENT=$(echo -e "$subcomponent" | sed -r 's/\<./\U&/g') \
     GO_PACKAGE=$(echo -e "$subcomponent" | sed -r 's/-/\//g') \


### PR DESCRIPTION
Dockerfiles required to build `v0.9.0` Knative serving images. Also added a couple more images to the `gen_dockerfiles.sh` script and bumped the version to `v0.9.0`.