### PR TITLE
Improve productization Dockerfile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ test-e2e:
 generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
-	./openshift/productization/generate-dockerfiles/gen_dockerfiles.sh openshift/productization/dist-git
 .PHONY: generate-dockerfiles
+
+generate-p12n-dockerfiles:
+	./openshift/productization/generate-dockerfiles/gen_dockerfiles.sh openshift/productization/dist-git
+.PHONY: generate-p12n-dockerfiles
 
 # Generates a ci-operator configuration for a specific branch.
 generate-ci-config:

--- a/openshift/productization/dist-git/Dockerfile.activator
+++ b/openshift/productization/dist-git/Dockerfile.activator
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/activator ./cmd/activator
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/activator /usr/bin/activator
+COPY --from=builder /tmp/activator /ko-app/activator
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-activator-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-activator-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Activator" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Activator" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Activator"
 
-ENTRYPOINT ["/usr/bin/activator"]
+ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/productization/dist-git/Dockerfile.autoscaler
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/autoscaler ./cmd/autoscaler
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/autoscaler /usr/bin/autoscaler
+COPY --from=builder /tmp/autoscaler /ko-app/autoscaler
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-autoscaler-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-autoscaler-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler"
 
-ENTRYPOINT ["/usr/bin/autoscaler"]
+ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/autoscaler-hpa ./cmd/autoscaler-hpa
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/autoscaler-hpa /usr/bin/autoscaler-hpa
+COPY --from=builder /tmp/autoscaler-hpa /ko-app/autoscaler-hpa
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-autoscaler-hpa-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-autoscaler-hpa-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA"
 
-ENTRYPOINT ["/usr/bin/autoscaler-hpa"]
+ENTRYPOINT ["/ko-app/autoscaler-hpa"]

--- a/openshift/productization/dist-git/Dockerfile.controller
+++ b/openshift/productization/dist-git/Dockerfile.controller
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/controller ./cmd/controller
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/controller /usr/bin/controller
+COPY --from=builder /tmp/controller /ko-app/controller
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-controller-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-controller-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Controller" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Controller" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Controller"
 
-ENTRYPOINT ["/usr/bin/controller"]
+ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/productization/dist-git/Dockerfile.networking-certmanager
+++ b/openshift/productization/dist-git/Dockerfile.networking-certmanager
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/networking-certmanager ./cmd/networking/certmanager
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/networking-certmanager /usr/bin/networking-certmanager
+COPY --from=builder /tmp/networking-certmanager /ko-app/networking-certmanager
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-certmanager-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-networking-certmanager-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Networking CertManager" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Networking CertManager" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking CertManager"
 
-ENTRYPOINT ["/usr/bin/networking-certmanager"]
+ENTRYPOINT ["/ko-app/networking-certmanager"]

--- a/openshift/productization/dist-git/Dockerfile.networking-istio
+++ b/openshift/productization/dist-git/Dockerfile.networking-istio
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/networking-istio ./cmd/networking/istio
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/networking-istio /usr/bin/networking-istio
+COPY --from=builder /tmp/networking-istio /ko-app/networking-istio
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-istio-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-networking-istio-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking Istio"
 
-ENTRYPOINT ["/usr/bin/networking-istio"]
+ENTRYPOINT ["/ko-app/networking-istio"]

--- a/openshift/productization/dist-git/Dockerfile.networking-nscert
+++ b/openshift/productization/dist-git/Dockerfile.networking-nscert
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/networking-nscert ./cmd/networking/nscert
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/networking-nscert /usr/bin/networking-nscert
+COPY --from=builder /tmp/networking-nscert /ko-app/networking-nscert
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-networking-nscert-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-networking-nscert-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Networking NSCert" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Networking NSCert" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking NSCert"
 
-ENTRYPOINT ["/usr/bin/networking-nscert"]
+ENTRYPOINT ["/ko-app/networking-nscert"]

--- a/openshift/productization/dist-git/Dockerfile.queue
+++ b/openshift/productization/dist-git/Dockerfile.queue
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/queue ./cmd/queue
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/queue /usr/bin/queue
+COPY --from=builder /tmp/queue /ko-app/queue
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-queue-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-queue-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Queue" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Queue" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Queue"
 
-ENTRYPOINT ["/usr/bin/queue"]
+ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/productization/dist-git/Dockerfile.webhook
+++ b/openshift/productization/dist-git/Dockerfile.webhook
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/webhook ./cmd/webhook
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/webhook /usr/bin/webhook
+COPY --from=builder /tmp/webhook /ko-app/webhook
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-serving-webhook-rhel8-container" \
       name="openshift-serverless-1-tech-preview/serving-webhook-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Webhook" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Webhook" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Webhook"
 
-ENTRYPOINT ["/usr/bin/webhook"]
+ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -9,7 +9,7 @@ COPY --from=builder /tmp/$SUBCOMPONENT /ko-app/$SUBCOMPONENT
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-$COMPONENT-$SUBCOMPONENT-rhel8-container" \
       name="openshift-serverless-1-tech-preview/$COMPONENT-$SUBCOMPONENT-rhel8" \
-      version="0.9.0" \
+      version="$VERSION" \
       summary="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
       maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -4,15 +4,15 @@ COPY . .
 RUN go build -o /tmp/$SUBCOMPONENT ./cmd/$GO_PACKAGE
 
 FROM ubi8:8-released
-COPY --from=builder /tmp/$SUBCOMPONENT /usr/bin/$SUBCOMPONENT
+COPY --from=builder /tmp/$SUBCOMPONENT /ko-app/$SUBCOMPONENT
 
 LABEL \
       com.redhat.component="openshift-serverless-1-tech-preview-$COMPONENT-$SUBCOMPONENT-rhel8-container" \
       name="openshift-serverless-1-tech-preview/$COMPONENT-$SUBCOMPONENT-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
-      maintainer="mthoemme@redhat.com" \
+      maintainer="wvanwinc@redhat.com" \
       description="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT"
 
-ENTRYPOINT ["/usr/bin/$SUBCOMPONENT"]
+ENTRYPOINT ["/ko-app/$SUBCOMPONENT"]

--- a/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
+++ b/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
@@ -12,6 +12,7 @@ do
     export CAPITALIZED_SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/-/ /g')
     export COMPONENT=$(echo -e "$component" | sed -e 's/\(.*\)/\L\1/g')
     export SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/\(.*\)/\L\1/g')
+    export VERSION=$(git rev-parse --abbrev-ref HEAD | sed -r 's/release-v//g')
     export GO_PACKAGE=$(echo -e "$SUBCOMPONENT" | sed -e 's/networking-/networking\//g')
     envsubst \
       < openshift/productization/generate-dockerfiles/Dockerfile.in \

--- a/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
+++ b/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
@@ -4,16 +4,16 @@ target_dir=$1
 
 component=Serving
 
-for subcomponent in Activator Autoscaler Autoscaler-HPA \
+for subcomponent in Activator Autoscaler Autoscaler-HPA Controller \
                     Networking-Istio Networking-CertManager Networking-NSCert \
                     Queue Webhook; \
 do
-    CAPITALIZED_COMPONENT=$component \
-    CAPITALIZED_SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/-/ /g') \
-    COMPONENT=$(echo -e "$component" | sed -e 's/\(.*\)/\L\1/g') \
-    SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/\(.*\)/\L\1/g') \
-    GO_PACKAGE=$(echo -e "$SUBCOMPONENT" | sed -e 's/networking-/networking\//g') \
+    export CAPITALIZED_COMPONENT=$component
+    export CAPITALIZED_SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/-/ /g')
+    export COMPONENT=$(echo -e "$component" | sed -e 's/\(.*\)/\L\1/g')
+    export SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/\(.*\)/\L\1/g')
+    export GO_PACKAGE=$(echo -e "$SUBCOMPONENT" | sed -e 's/networking-/networking\//g')
     envsubst \
       < openshift/productization/generate-dockerfiles/Dockerfile.in \
-      > ${target_dir}/Dockerfile.$subcomponent
+      > ${target_dir}/Dockerfile.$SUBCOMPONENT
 done

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -19,6 +19,7 @@ git checkout -b "$target" "$release"
 git fetch openshift master
 git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
 make generate-dockerfiles
+make generate-p12n-dockerfiles
 make RELEASE=$release generate-release
 make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml


### PR DESCRIPTION
Fixes to `Dockerfile.in` that hadn't been made on `master` at the time the `release-v0.9.0` branch was created, along with some other improvements.

- Replace `/usr/bin` with `/ko-app`.
- Automatically determine the `VERSION` using the release branch name.
- Create a new make target to generate only the p12n Dockerfiles, instead of the CI and productization Dockerfiles together. This allows us to only generate p12n Dockerfiles when the release branch is created.
- Fixed a bug introduced in 2eb91d91a where the suffix of the Dockerfiles used the capitalized version of the subcomponent.
- Add the missing Dockerfile for the `controller`.