### PR TITLE
Change maintainer to serverless-support@redhat.com

### DIFF
--- a/openshift/productization/dist-git/Dockerfile.activator
+++ b/openshift/productization/dist-git/Dockerfile.activator
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-activator-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Activator" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Activator" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Activator"
 

--- a/openshift/productization/dist-git/Dockerfile.autoscaler
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-autoscaler-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler"
 

--- a/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-autoscaler-hpa-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler HPA"
 

--- a/openshift/productization/dist-git/Dockerfile.controller
+++ b/openshift/productization/dist-git/Dockerfile.controller
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-controller-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Controller" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Controller" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Controller"
 

--- a/openshift/productization/dist-git/Dockerfile.networking-certmanager
+++ b/openshift/productization/dist-git/Dockerfile.networking-certmanager
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-networking-certmanager-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Networking CertManager" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Networking CertManager" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking CertManager"
 

--- a/openshift/productization/dist-git/Dockerfile.networking-istio
+++ b/openshift/productization/dist-git/Dockerfile.networking-istio
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-networking-istio-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Networking Istio" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking Istio"
 

--- a/openshift/productization/dist-git/Dockerfile.networking-nscert
+++ b/openshift/productization/dist-git/Dockerfile.networking-nscert
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-networking-nscert-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Networking NSCert" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Networking NSCert" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Networking NSCert"
 

--- a/openshift/productization/dist-git/Dockerfile.queue
+++ b/openshift/productization/dist-git/Dockerfile.queue
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-queue-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Queue" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Queue" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Queue"
 

--- a/openshift/productization/dist-git/Dockerfile.webhook
+++ b/openshift/productization/dist-git/Dockerfile.webhook
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/serving-webhook-rhel8" \
       version="0.9.0" \
       summary="Red Hat OpenShift Serverless 1 Serving Webhook" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Webhook" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Webhook"
 

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -11,7 +11,7 @@ LABEL \
       name="openshift-serverless-1-tech-preview/$COMPONENT-$SUBCOMPONENT-rhel8" \
       version="$VERSION" \
       summary="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
-      maintainer="wvanwinc@redhat.com" \
+      maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT"
 


### PR DESCRIPTION
OpenShift generally required the maintainer to be a mailing list. With this in mind, we can set it to `serverless-support@redhat.com`.