### PR TITLE
Remove pod logs dump from e2e script

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -209,19 +209,13 @@ function run_e2e_tests(){
 function dump_openshift_olm_state(){
   echo ">>> subscriptions.operators.coreos.com:"
   oc get subscriptions.operators.coreos.com -o yaml --all-namespaces   # This is for status checking.
-
-  echo ">>> catalog operator log:"
-  oc logs -n openshift-operator-lifecycle-manager deployment/catalog-operator
 }
 
-function dump_openshift_ingress_state(){
+function dump_routes_state(){
   echo ">>> routes.route.openshift.io:"
   oc get routes.route.openshift.io -o yaml --all-namespaces
   echo ">>> routes.serving.knative.dev:"
   oc get routes.serving.knative.dev -o yaml --all-namespaces
-
-  echo ">>> openshift-ingress log:"
-  oc logs deployment/knative-openshift-ingress -n $SERVING_NAMESPACE
 }
 
 function tag_test_images() {
@@ -260,7 +254,7 @@ failed=0
 
 (( failed )) && dump_openshift_olm_state
 
-(( failed )) && dump_openshift_ingress_state
+(( failed )) && dump_routes_state
 
 (( failed )) && exit 1
 


### PR DESCRIPTION
This patch removes command to collect pod logs as all logs are collected in
`artifacts/e2e-aws-ocp-42/pods/`*1.

*1 For example
https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/pr-logs/pull/openshift_knative-serving/339/pull-ci-openshift-knative-serving-release-next-4.2-e2e-aws-ocp-42/18/artifacts/e2e-aws-ocp-42/pods/

/cc @markusthoemmes @savitaashture 