### PR TITLE
Simplify the e2e tests script by pulling images from ci registry and adjust release creation.

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,22 +1,17 @@
 #!/usr/bin/env bash
 
-source $(dirname $0)/../test/e2e-common.sh
-source $(dirname $0)/release/resolve.sh
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
+source "$(dirname "$0")/release/resolve.sh"
 
 set -x
 
-readonly K8S_CLUSTER_OVERRIDE=$(oc config current-context | awk -F'/' '{print $2}')
-readonly API_SERVER=$(oc config view --minify | grep server | awk -F'//' '{print $2}' | awk -F':' '{print $1}')
-readonly INTERNAL_REGISTRY="${INTERNAL_REGISTRY:-"image-registry.openshift-image-registry.svc:5000"}"
-readonly USER=$KUBE_SSH_USER #satisfy e2e_flags.go#initializeFlags()
-readonly OPENSHIFT_REGISTRY="${OPENSHIFT_REGISTRY:-"registry.svc.ci.openshift.org"}"
-readonly INSECURE="${INSECURE:-"false"}"
-readonly TEST_NAMESPACE=serving-tests
-readonly TEST_NAMESPACE_ALT=serving-tests-alt
 readonly SERVING_NAMESPACE=knative-serving
 readonly SERVICEMESH_NAMESPACE=knative-serving-ingress
-export GATEWAY_NAMESPACE_OVERRIDE="$SERVICEMESH_NAMESPACE"
-readonly TARGET_IMAGE_PREFIX="$INTERNAL_REGISTRY/$SERVING_NAMESPACE/knative-serving-"
+
+# A golang template to point the tests to the right image coordinates.
+# {{.Name}} is the name of the image, for example 'autoscale'.
+readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-test-{{.Name}}"
 
 # The OLM global namespace was moved to openshift-marketplace since v4.2
 # ref: https://jira.coreos.com/browse/OLM-1190
@@ -30,10 +25,11 @@ function scale_up_workers(){
   oc get machineset -n ${cluster_api_ns} --show-labels
 
   # Get the name of the first machineset that has at least 1 replica
-  local machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  local machineset
+  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
   # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
-  oc patch machineset -n ${cluster_api_ns} ${machineset} -p '{"spec":{"replicas":6}}' --type=merge
-  wait_until_machineset_scales_up ${cluster_api_ns} ${machineset} 6
+  oc patch machineset -n ${cluster_api_ns} "${machineset}" -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} "${machineset}" 6
 }
 
 # Waits until the machineset in the given namespaces scales up to the
@@ -43,8 +39,9 @@ function scale_up_workers(){
 #             $3 - desired number of replicas
 function wait_until_machineset_scales_up() {
   echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
-  for i in {1..150}; do  # timeout after 15 minutes
-    local available=$(oc get machineset -n $1 $2 -o jsonpath="{.status.availableReplicas}")
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local available
+    available=$(oc get machineset -n "$1" "$2" -o jsonpath="{.status.availableReplicas}")
     if [[ ${available} -eq $3 ]]; then
       echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
       return 0
@@ -52,7 +49,7 @@ function wait_until_machineset_scales_up() {
     echo -n "."
     sleep 6
   done
-  echo - "\n\nError: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  echo - "Error: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
   return 1
 }
 
@@ -60,8 +57,9 @@ function wait_until_machineset_scales_up() {
 # Parameters: $1 - hostname
 function wait_until_hostname_resolves() {
   echo -n "Waiting until hostname $1 resolves via DNS"
-  for i in {1..150}; do  # timeout after 15 minutes
-    local output="$(host -t a $1 | grep 'has address')"
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local output
+    output=$(host -t a "$1" | grep 'has address')
     if [[ -n "${output}" ]]; then
       echo -e "\n${output}"
       return 0
@@ -89,7 +87,7 @@ function install_knative(){
   oc new-project $SERVING_NAMESPACE
 
   # Install CatalogSource in OLM namespace
-  oc apply -n $OLM_NAMESPACE -f openshift/olm/knative-serving.catalogsource.yaml
+  envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
   timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE
 
@@ -108,9 +106,6 @@ metadata:
   namespace: ${SERVING_NAMESPACE}
 EOF
 
-  # Create imagestream for images generated in CI namespace
-  tag_core_images openshift/release/knative-serving-ci.yaml
-
   # Wait for 4 pods to appear first
   timeout 900 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
   wait_until_pods_running $SERVING_NAMESPACE || return 1
@@ -122,140 +117,71 @@ EOF
 }
 
 function deploy_serverless_operator(){
-  local NAME="serverless-operator"
-  local OPERATOR_NS=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
+  local name="serverless-operator"
+  local operator_ns
+  operator_ns=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
 
   cat <<-EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: ${NAME}-subscription
-  namespace: ${OPERATOR_NS}
+  name: ${name}-subscription
+  namespace: ${operator_ns}
 spec:
-  source: ${NAME}
+  source: ${name}
   sourceNamespace: $OLM_NAMESPACE
-  name: ${NAME}
+  name: ${name}
   channel: techpreview
 EOF
 }
 
-function tag_core_images(){
-  local resolved_file_name=$1
-
-  oc policy add-role-to-group system:image-puller system:serviceaccounts:${SERVING_NAMESPACE} --namespace=${OPENSHIFT_BUILD_NAMESPACE}
-
-  echo ">> Creating imagestream tags for images referenced in yaml files"
-  IMAGE_NAMES=$(cat $resolved_file_name | grep -i "image:" | grep "$INTERNAL_REGISTRY" | awk '{print $2}' | awk -F '/' '{print $3}')
-  for name in $IMAGE_NAMES; do
-    tag_built_image ${name} ${name}
-  done
-}
-
-function create_test_resources_openshift() {
-  echo ">> Creating test resources for OpenShift (test/config/)"
-
-  resolve_resources test/config/ tests-resolved.yaml $TARGET_IMAGE_PREFIX
-
-  tag_core_images tests-resolved.yaml
-
-  oc apply -f tests-resolved.yaml
-
-  echo ">> Ensuring pods in test namespaces can access test images"
-  oc policy add-role-to-group system:image-puller system:serviceaccounts:${TEST_NAMESPACE} --namespace=${SERVING_NAMESPACE}
-  oc policy add-role-to-group system:image-puller system:serviceaccounts:${TEST_NAMESPACE_ALT} --namespace=${SERVING_NAMESPACE}
-  oc policy add-role-to-group system:image-puller system:serviceaccounts:knative-testing --namespace=${SERVING_NAMESPACE}
-
-  echo ">> Creating imagestream tags for all test images"
-  tag_test_images test/test_images
-}
-
-function create_test_namespace(){
-  oc new-project $TEST_NAMESPACE
-  oc new-project $TEST_NAMESPACE_ALT
-  oc adm policy add-scc-to-user privileged -z default -n $TEST_NAMESPACE
-  oc adm policy add-scc-to-user privileged -z default -n $TEST_NAMESPACE_ALT
-  # adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
-  oc adm policy add-scc-to-user anyuid -z default -n $TEST_NAMESPACE
-}
-
 function run_e2e_tests(){
+  echo ">> Creating test resources for OpenShift (test/config/)"
+  # Removing unneeded test resources.
+  rm test/config/100-istio-default-domain.yaml
+  oc apply -f test/config
+
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
+  # adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
+  oc adm policy add-scc-to-user anyuid -z default -n serving-tests
+
   header "Running tests"
   failed=0
+
+  # Needed because tests assume that istio is found in "istio-system"
+  export GATEWAY_NAMESPACE_OVERRIDE="$SERVICEMESH_NAMESPACE"
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -short -parallel=3 \
     ./test/e2e \
     --kubeconfig "$KUBECONFIG" \
-    --dockerrepo "${INTERNAL_REGISTRY}/${SERVING_NAMESPACE}" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --resolvabledomain || failed=1
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
     ./test/conformance/runtime/... \
     --kubeconfig "$KUBECONFIG" \
-    --dockerrepo "${INTERNAL_REGISTRY}/${SERVING_NAMESPACE}" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --resolvabledomain || failed=1
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
     ./test/conformance/api/... \
     --kubeconfig "$KUBECONFIG" \
-    --dockerrepo "${INTERNAL_REGISTRY}/${SERVING_NAMESPACE}" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --resolvabledomain || failed=1
 
   return $failed
 }
 
-function dump_openshift_olm_state(){
-  echo ">>> subscriptions.operators.coreos.com:"
-  oc get subscriptions.operators.coreos.com -o yaml --all-namespaces   # This is for status checking.
-}
-
-function dump_routes_state(){
-  echo ">>> routes.route.openshift.io:"
-  oc get routes.route.openshift.io -o yaml --all-namespaces
-  echo ">>> routes.serving.knative.dev:"
-  oc get routes.serving.knative.dev -o yaml --all-namespaces
-}
-
-function tag_test_images() {
-  local dir=$1
-  image_dirs="$(find ${dir} -mindepth 1 -maxdepth 1 -type d)"
-
-  for image_dir in ${image_dirs}; do
-    name=$(basename ${image_dir})
-    tag_built_image knative-serving-test-${name} ${name}
-  done
-
-  # TestContainerErrorMsg also needs an invalidhelloworld imagestream
-  # to exist but NOT have a `latest` tag
-  oc tag --insecure=${INSECURE} -n ${SERVING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-test-helloworld invalidhelloworld:not_latest
-}
-
-function tag_built_image() {
-  local remote_name=$1
-  local local_name=$2
-  oc tag --insecure=${INSECURE} -n ${SERVING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${remote_name} ${local_name}:latest
-}
-
 scale_up_workers || exit 1
 
-create_test_namespace || exit 1
-
 failed=0
-
 (( !failed )) && install_knative || failed=1
-
-(( !failed )) && create_test_resources_openshift || failed=1
-
 (( !failed )) && run_e2e_tests || failed=1
-
 (( failed )) && dump_cluster_state
-
-(( failed )) && dump_openshift_olm_state
-
-(( failed )) && dump_routes_state
-
 (( failed )) && exit 1
 
 success

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -354,23 +354,19 @@ data:
                       - name: OPERATOR_NAME
                         value: knative-serving-operator
                       - name: IMAGE_QUEUE
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-queue
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-queue
                       - name: IMAGE_activator
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-activator
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-activator
                       - name: IMAGE_autoscaler
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-autoscaler
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-autoscaler
                       - name: IMAGE_autoscaler-hpa
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-autoscaler-hpa
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-autoscaler-hpa
                       - name: IMAGE_controller
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-controller
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-controller
                       - name: IMAGE_networking-istio
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-istio
-                      - name: IMAGE_networking-ns-cert
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-nscert
-                      - name: IMAGE_networking-certmanager
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-certmanager
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-istio
                       - name: IMAGE_webhook
-                        value: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-webhook
+                        value: registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-serving-webhook
                       image: quay.io/openshift-knative/knative-serving-operator:v0.9.0-1.2.0-05
                       args:
                         - --filename=https://raw.githubusercontent.com/openshift/knative-serving/release-next/openshift/release/knative-serving-ci.yaml # remove this from individual release branches

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -23,6 +23,16 @@ function resolve_file() {
   local image_prefix=$3
   local image_tag=$4
 
+  # Skip cert-manager, it's not part of upstream's release YAML either.
+  if grep -q 'networking.knative.dev/certificate-provider: cert-manager' "$1"; then
+    return
+  fi
+
+  # Skip nscert, it's not part of upstream's release YAML either.
+  if grep -q 'networking.knative.dev/wildcard-certificate-provider: nscert' "$1"; then
+    return
+  fi
+
   echo "---" >> "$to"
   # 1. Rewrite image references
   # 2. Update config map entry


### PR DESCRIPTION
Green PR on release-next https://github.com/openshift/knative-serving/pull/346.

This pulls all the necessary images from the CI registry, so we don't need to pull them into the local registry and tag them and add rights to pull them and and and.

It also slightly adjusts the way we build the release YAMLs to more closely match the upstream YAMLs.