### PR TITLE
Make CI built Dockerfiles self-contained.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,6 @@ GOOS=linux
 CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio ./cmd/networking/certmanager ./cmd/networking/nscert
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
 
-install:
-	for img in $(CORE_IMAGES); do \
-		go install $$img ; \
-	done
-.PHONY: install
-
-test-install:
-	for img in $(TEST_IMAGES); do \
-		go install $$img ; \
-	done
-.PHONY: test-install
-
 test-e2e:
 	./openshift/e2e-tests-openshift.sh
 .PHONY: test-e2e

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD ${bin} /ko-app/${bin}
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/${bin} ./cmd/${bin}
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/${bin} /ko-app/${bin}
+
+USER 65532
 ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -4,7 +4,7 @@ branch=${1-'knative-v0.3'}
 
 cat <<EOF
 tag_specification:
-  name: '4.1'
+  name: '4.2'
   namespace: ocp
 promotion:
   cluster: https://api.ci.openshift.org
@@ -12,15 +12,13 @@ promotion:
   name: $branch
 base_images:
   base:
-    name: '4.1'
+    name: '4.2'
     namespace: ocp
     tag: base
 build_root:
   project_image:
     dockerfile_path: openshift/ci-operator/build-image/Dockerfile
 canonical_go_repository: knative.dev/serving
-binary_build_commands: make install
-test_binary_build_commands: make test-install
 tests:
 - as: e2e-aws
   commands: "make test-e2e"
@@ -42,11 +40,6 @@ for img in $core_images; do
   cat <<EOF
 - dockerfile_path: openshift/ci-operator/knative-images/$image_base/Dockerfile
   from: base
-  inputs:
-    bin:
-      paths:
-      - destination_dir: .
-        source_path: /go/bin/$image_base
   to: knative-serving-$image_base
 EOF
 done
@@ -57,11 +50,6 @@ for img in $test_images; do
   cat <<EOF
 - dockerfile_path: openshift/ci-operator/knative-test-images/$image_base/Dockerfile
   from: base
-  inputs:
-    test-bin:
-      paths:
-      - destination_dir: .
-        source_path: /go/bin/$image_base
   to: knative-serving-test-$image_base
 EOF
 done

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -7,7 +7,7 @@ function generate_dockefiles() {
   for img in $@; do
     local image_base=$(basename $img)
     mkdir -p $target_dir/$image_base
-    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    bin=$image_base envsubst '${bin}' < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
   done
 }
 

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD activator /ko-app/activator
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/activator ./cmd/activator
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/activator /ko-app/activator
+
+USER 65532
 ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD autoscaler-hpa /ko-app/autoscaler-hpa
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/autoscaler-hpa ./cmd/autoscaler-hpa
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/autoscaler-hpa /ko-app/autoscaler-hpa
+
+USER 65532
 ENTRYPOINT ["/ko-app/autoscaler-hpa"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD autoscaler /ko-app/autoscaler
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/autoscaler ./cmd/autoscaler
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/autoscaler /ko-app/autoscaler
+
+USER 65532
 ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/ci-operator/knative-images/certmanager/Dockerfile
+++ b/openshift/ci-operator/knative-images/certmanager/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD certmanager /ko-app/certmanager
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/certmanager ./cmd/certmanager
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/certmanager /ko-app/certmanager
+
+USER 65532
 ENTRYPOINT ["/ko-app/certmanager"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD controller /ko-app/controller
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/controller ./cmd/controller
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/controller /ko-app/controller
+
+USER 65532
 ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD istio /ko-app/istio
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/istio ./cmd/istio
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/istio /ko-app/istio
+
+USER 65532
 ENTRYPOINT ["/ko-app/istio"]

--- a/openshift/ci-operator/knative-images/nscert/Dockerfile
+++ b/openshift/ci-operator/knative-images/nscert/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD nscert /ko-app/nscert
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/nscert ./cmd/nscert
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/nscert /ko-app/nscert
+
+USER 65532
 ENTRYPOINT ["/ko-app/nscert"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD queue /ko-app/queue
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/queue ./cmd/queue
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/queue /ko-app/queue
+
+USER 65532
 ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD webhook /ko-app/webhook
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/webhook ./cmd/webhook
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/webhook /ko-app/webhook
+
+USER 65532
 ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD autoscale /ko-app/autoscale
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/autoscale ./cmd/autoscale
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/autoscale /ko-app/autoscale
+
+USER 65532
 ENTRYPOINT ["/ko-app/autoscale"]

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD failing /ko-app/failing
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/failing ./cmd/failing
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/failing /ko-app/failing
+
+USER 65532
 ENTRYPOINT ["/ko-app/failing"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD grpc-ping /ko-app/grpc-ping
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/grpc-ping ./cmd/grpc-ping
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/grpc-ping /ko-app/grpc-ping
+
+USER 65532
 ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD hellovolume /ko-app/hellovolume
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/hellovolume ./cmd/hellovolume
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/hellovolume /ko-app/hellovolume
+
+USER 65532
 ENTRYPOINT ["/ko-app/hellovolume"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD helloworld /ko-app/helloworld
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/helloworld ./cmd/helloworld
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/helloworld /ko-app/helloworld
+
+USER 65532
 ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD httpproxy /ko-app/httpproxy
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/httpproxy ./cmd/httpproxy
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/httpproxy /ko-app/httpproxy
+
+USER 65532
 ENTRYPOINT ["/ko-app/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD observed-concurrency /ko-app/observed-concurrency
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/observed-concurrency ./cmd/observed-concurrency
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/observed-concurrency /ko-app/observed-concurrency
+
+USER 65532
 ENTRYPOINT ["/ko-app/observed-concurrency"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD pizzaplanetv1 /ko-app/pizzaplanetv1
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/pizzaplanetv1 ./cmd/pizzaplanetv1
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/pizzaplanetv1 /ko-app/pizzaplanetv1
+
+USER 65532
 ENTRYPOINT ["/ko-app/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD pizzaplanetv2 /ko-app/pizzaplanetv2
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/pizzaplanetv2 ./cmd/pizzaplanetv2
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/pizzaplanetv2 /ko-app/pizzaplanetv2
+
+USER 65532
 ENTRYPOINT ["/ko-app/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD runtime /ko-app/runtime
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/runtime ./cmd/runtime
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/runtime /ko-app/runtime
+
+USER 65532
 ENTRYPOINT ["/ko-app/runtime"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD singlethreaded /ko-app/singlethreaded
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/singlethreaded ./cmd/singlethreaded
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/singlethreaded /ko-app/singlethreaded
+
+USER 65532
 ENTRYPOINT ["/ko-app/singlethreaded"]

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD timeout /ko-app/timeout
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/timeout ./cmd/timeout
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/timeout /ko-app/timeout
+
+USER 65532
 ENTRYPOINT ["/ko-app/timeout"]

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
-USER 65532
+FROM openshift/origin-release:golang-1.13 AS builder
 
-ADD wsserver /ko-app/wsserver
+WORKDIR ${GOPATH}/src/knative.dev/serving
+COPY . .
+RUN go build -o /tmp/wsserver ./cmd/wsserver
+
+FROM openshift/origin-base
+COPY --from=builder /tmp/wsserver /ko-app/wsserver
+
+USER 65532
 ENTRYPOINT ["/ko-app/wsserver"]


### PR DESCRIPTION
This simplifies the build-process for all of our images by making them self-contained multi-stage Dockerfiles. That greatly simplifies the flow in CI and reduces the noise in the CI config files, making them easier to manage for humans.