### PR TITLE
Prefix the VERSION string with v

### DIFF
--- a/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
+++ b/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
@@ -12,7 +12,7 @@ do
     export CAPITALIZED_SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/-/ /g')
     export COMPONENT=$(echo -e "$component" | sed -e 's/\(.*\)/\L\1/g')
     export SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/\(.*\)/\L\1/g')
-    export VERSION=$(git rev-parse --abbrev-ref HEAD | sed -r 's/release-v//g')
+    export VERSION=$(git rev-parse --abbrev-ref HEAD | sed -r 's/release-//g')
     export GO_PACKAGE=$(echo -e "$SUBCOMPONENT" | sed -e 's/networking-/networking\//g')
     envsubst \
       < openshift/productization/generate-dockerfiles/Dockerfile.in \


### PR DESCRIPTION
The `gen_dockerfiles.sh` script should only be run on a branch that has a name beginning `release-`.