### PR TITLE
Fix release branch script to allow for multi-digit versions.

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -4,7 +4,7 @@
 
 release=$1
 target=$2
-release_regexp="^release-v([0-9]\.)+([0-9])$"
+release_regexp="^release-v([0-9]+\.)+([0-9])$"
 
 if [[ ! $target =~ $release_regexp ]]; then
     echo "\"$target\" is wrong format. Must have proper format like release-v0.1.2"


### PR DESCRIPTION
We're in the double digits now (0.12.0 for example), so this needs to allow more than one digit per version part.