### PR TITLE
[TEST ONLY] Bump servleress-operator to v1.5.0 and remove istio for Kourier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+#This makefile is used by ci-operator
+
+CGO_ENABLED=0
+GOOS=linux
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio ./cmd/networking/certmanager ./cmd/networking/nscert
+TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
+
+install:
+	for img in $(CORE_IMAGES); do \
+		go install $$img ; \
+	done
+.PHONY: install
+
+test-install:
+	for img in $(TEST_IMAGES); do \
+		go install $$img ; \
+	done
+.PHONY: test-install
+
+test-e2e:
+	./openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Generate Dockerfiles for core and test images used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+.PHONY: generate-dockerfiles
+
+generate-p12n-dockerfiles:
+	./openshift/productization/generate-dockerfiles/gen_dockerfiles.sh openshift/productization/dist-git
+.PHONY: generate-p12n-dockerfiles
+
+# Generates a ci-operator configuration for a specific branch.
+generate-ci-config:
+	./openshift/ci-operator/generate-ci-config.sh $(BRANCH) > ci-operator-config.yaml
+.PHONY: generate-ci-config
+
+# Generate an aggregated knative yaml file with replaced image references
+generate-release:
+	./openshift/release/generate-release.sh $(RELEASE)
+.PHONY: generate-release

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio ./cmd/networking/certmanager ./cmd/networking/nscert
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/certmanager ./cmd/networking/nscert
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
 
 install:

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- evankanderson
-- mattmoor
-- mdemirhan
-- vaikas
+- serving-approvers
+
+reviewers:
+- serving-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,68 +1,148 @@
 aliases:
-  serving-api-approvers:
-  - dgerd
-  - dprotaso
+  serving-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
-  serving-api-reviewers:
-  - dgerd
-  - dprotaso
+  - vdemeester
+  - evanchooly
+  - arilivigni
+  serving-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
+  - vdemeester
+  - evanchooly
+  - arilivigni
 
-  # TOC + WG leads
-  serving-wg-leads:
-  - evankanderson  # TOC
-  - mattmoor       # TOC/Serving
-  - vaikas         # TOC
-  - dprotaso       # Serving
-  - markusthoemmes # Scaling
-  - mdemirhan      # Networking
-  - tcnghia        # Networking
-  - vagababov      # Scaling
+  serving-api-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
+  serving-api-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
 
   autoscaling-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - vagababov
+  - vdemeester
+  - evanchooly
+  - arilivigni
   autoscaling-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - taragu
-  - vagababov
-  - yanweiguo
+  - vdemeester
+  - evanchooly
+  - arilivigni
 
   monitoring-approvers:
-  - mdemirhan
-  - yanweiguo
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
   monitoring-reviewers:
-  - mdemirhan
-  - yanweiguo
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
 
   productivity-approvers:
-  - chaodaiG
-  - chizhg
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
   productivity-reviewers:
-  - chaodaiG
-  - coryrc
-  - chizhg
-  - steuhs
-  - yt3liu
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
 
   networking-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - tcnghia
-  - vagababov
+  - vdemeester
+  - evanchooly
+  - arilivigni
   networking-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - nak3
-  - tcnghia
-  - vagababov
-  - yanweiguo
-  - ZhiminXiang
+  - vdemeester
+  - evanchooly
+  - arilivigni
+
+  build-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
+  build-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
+

--- a/container.yaml
+++ b/container.yaml
@@ -1,0 +1,7 @@
+go:
+  modules:
+  - module: github.com/knative/serving
+image_build_method: imagebuilder
+platforms:
+  only:
+  - x86_64

--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,3 @@
+x86_64:
+- rhel-8-for-x86_64-baseos-rpms
+- rhel-8-for-x86_64-appstream-rpms

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD ${bin} /ko-app/${bin}
+ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,11 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM openshift/origin-release:golang-1.13
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+branch=${1-'knative-v0.3'}
+
+cat <<EOF
+tag_specification:
+  name: '4.1'
+  namespace: ocp
+promotion:
+  cluster: https://api.ci.openshift.org
+  namespace: openshift
+  name: $branch
+base_images:
+  base:
+    name: '4.1'
+    namespace: ocp
+    tag: base
+build_root:
+  project_image:
+    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
+canonical_go_repository: knative.dev/serving
+binary_build_commands: make install
+test_binary_build_commands: make test-install
+tests:
+- as: e2e-aws
+  commands: "make test-e2e"
+  openshift_installer_src:
+    cluster_profile: aws
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+images:
+EOF
+
+core_images=$(find ./openshift/ci-operator/knative-images -mindepth 1 -maxdepth 1 -type d)
+for img in $core_images; do
+  image_base=$(basename $img)
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-serving-$image_base
+EOF
+done
+
+test_images=$(find ./openshift/ci-operator/knative-test-images -mindepth 1 -maxdepth 1 -type d)
+for img in $test_images; do
+  image_base=$(basename $img)
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-test-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    test-bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-serving-test-$image_base
+EOF
+done

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD activator /ko-app/activator
+ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD autoscaler-hpa /ko-app/autoscaler-hpa
+ENTRYPOINT ["/ko-app/autoscaler-hpa"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD autoscaler /ko-app/autoscaler
+ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/ci-operator/knative-images/certmanager/Dockerfile
+++ b/openshift/ci-operator/knative-images/certmanager/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD certmanager /ko-app/certmanager
+ENTRYPOINT ["/ko-app/certmanager"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD controller /ko-app/controller
+ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
-USER 65532
-
-ADD istio /ko-app/istio
-ENTRYPOINT ["/ko-app/istio"]

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD istio /ko-app/istio
+ENTRYPOINT ["/ko-app/istio"]

--- a/openshift/ci-operator/knative-images/nscert/Dockerfile
+++ b/openshift/ci-operator/knative-images/nscert/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD nscert /ko-app/nscert
+ENTRYPOINT ["/ko-app/nscert"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD queue /ko-app/queue
+ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD webhook /ko-app/webhook
+ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD autoscale /ko-app/autoscale
+ENTRYPOINT ["/ko-app/autoscale"]

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD failing /ko-app/failing
+ENTRYPOINT ["/ko-app/failing"]

--- a/openshift/ci-operator/knative-test-images/flaky/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/flaky/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD flaky /ko-app/flaky
+ENTRYPOINT ["/ko-app/flaky"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD grpc-ping /ko-app/grpc-ping
+ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD hellovolume /ko-app/hellovolume
+ENTRYPOINT ["/ko-app/hellovolume"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD helloworld /ko-app/helloworld
+ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD httpproxy /ko-app/httpproxy
+ENTRYPOINT ["/ko-app/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD observed-concurrency /ko-app/observed-concurrency
+ENTRYPOINT ["/ko-app/observed-concurrency"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD pizzaplanetv1 /ko-app/pizzaplanetv1
+ENTRYPOINT ["/ko-app/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD pizzaplanetv2 /ko-app/pizzaplanetv2
+ENTRYPOINT ["/ko-app/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD runtime /ko-app/runtime
+ENTRYPOINT ["/ko-app/runtime"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD singlethreaded /ko-app/singlethreaded
+ENTRYPOINT ["/ko-app/singlethreaded"]

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD timeout /ko-app/timeout
+ENTRYPOINT ["/ko-app/timeout"]

--- a/openshift/ci-operator/knative-test-images/wsserver-hostname/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver-hostname/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD wsserver-hostname /ko-app/wsserver-hostname
+ENTRYPOINT ["/ko-app/wsserver-hostname"]

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD wsserver /ko-app/wsserver
+ENTRYPOINT ["/ko-app/wsserver"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -128,7 +128,7 @@ function deploy_serverless_operator(){
   local operator_ns
   operator_ns=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
 
-  # TODO: master branch will not work this file path. Probably wget is necessary.?
+  # Create configmap to use the latest manifest.
   oc create configmap ko-data -n $operator_ns --from-file="openshift/release/knative-serving-ci.yaml"
 
   cat <<-EOF | oc apply -f -

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -93,6 +93,7 @@ function install_knative(){
   export IMAGE_autoscaler_hpa=${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler-hpa}
   export IMAGE_controller=${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}
   export IMAGE_webhook=${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}
+  export IMAGE_kourier=${IMAGE_FORMAT//\$\{component\}/kourier}
   envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
   timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
+source "$(dirname "$0")/release/resolve.sh"
+
+set -x
+
+readonly SERVING_NAMESPACE=knative-serving
+readonly SERVICEMESH_NAMESPACE=knative-serving-ingress
+
+# A golang template to point the tests to the right image coordinates.
+# {{.Name}} is the name of the image, for example 'autoscale'.
+readonly TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-serving-test-{{.Name}}}"
+
+# The OLM global namespace was moved to openshift-marketplace since v4.2
+# ref: https://jira.coreos.com/browse/OLM-1190
+readonly OLM_NAMESPACE="openshift-marketplace"
+
+env
+
+function scale_up_workers(){
+  local cluster_api_ns="openshift-machine-api"
+
+  oc get machineset -n ${cluster_api_ns} --show-labels
+
+  # Get the name of the first machineset that has at least 1 replica
+  local machineset
+  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
+  oc patch machineset -n ${cluster_api_ns} "${machineset}" -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} "${machineset}" 6
+}
+
+# Waits until the machineset in the given namespaces scales up to the
+# desired number of replicas
+# Parameters: $1 - namespace
+#             $2 - machineset name
+#             $3 - desired number of replicas
+function wait_until_machineset_scales_up() {
+  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local available
+    available=$(oc get machineset -n "$1" "$2" -o jsonpath="{.status.availableReplicas}")
+    if [[ ${available} -eq $3 ]]; then
+      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo - "Error: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  return 1
+}
+
+# Waits until the given hostname resolves via DNS
+# Parameters: $1 - hostname
+function wait_until_hostname_resolves() {
+  echo -n "Waiting until hostname $1 resolves via DNS"
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local output
+    output=$(host -t a "$1" | grep 'has address')
+    if [[ -n "${output}" ]]; then
+      echo -e "\n${output}"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\nERROR: timeout waiting for hostname $1 to resolve via DNS"
+  return 1
+}
+
+# Loops until duration (car) is exceeded or command (cdr) returns non-zero
+function timeout() {
+  SECONDS=0; TIMEOUT=$1; shift
+  while eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && return 1
+  done
+  return 0
+}
+
+function install_knative(){
+  header "Installing Knative"
+
+  oc new-project $SERVING_NAMESPACE
+
+  # Install CatalogSource in OLM namespace
+  export IMAGE_QUEUE=${IMAGE_FORMAT//\$\{component\}/knative-serving-queue}
+  export IMAGE_activator=${IMAGE_FORMAT//\$\{component\}/knative-serving-activator}
+  export IMAGE_autoscaler=${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler}
+  export IMAGE_autoscaler_hpa=${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler-hpa}
+  export IMAGE_controller=${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}
+  export IMAGE_networking_istio=${IMAGE_FORMAT//\$\{component\}/knative-serving-istio}
+  export IMAGE_webhook=${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}
+  envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
+  timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
+  wait_until_pods_running $OLM_NAMESPACE
+
+  # Deploy Serverless Operator
+  deploy_serverless_operator
+
+  # Wait for the CRD to appear
+  timeout 900 '[[ $(oc get crd | grep -c knativeservings) -eq 0 ]]' || return 1
+
+  # Install Knative Serving
+  cat <<-EOF | oc apply -f -
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: ${SERVING_NAMESPACE}
+EOF
+
+  # Wait for 4 pods to appear first
+  timeout 900 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
+  wait_until_pods_running $SERVING_NAMESPACE || return 1
+
+  wait_until_service_has_external_ip $SERVICEMESH_NAMESPACE istio-ingressgateway || fail_test "Ingress has no external IP"
+  wait_until_hostname_resolves "$(kubectl get svc -n $SERVICEMESH_NAMESPACE istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+
+  header "Knative Installed successfully"
+}
+
+function deploy_serverless_operator(){
+  local name="serverless-operator"
+  local operator_ns
+  operator_ns=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
+
+  cat <<-EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ${name}-subscription
+  namespace: ${operator_ns}
+spec:
+  source: ${name}
+  sourceNamespace: $OLM_NAMESPACE
+  name: ${name}
+  channel: techpreview
+EOF
+}
+
+function run_e2e_tests(){
+  echo ">> Creating test resources for OpenShift (test/config/)"
+  # Removing unneeded test resources.
+  rm test/config/100-istio-default-domain.yaml
+  oc apply -f test/config
+
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
+  # adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
+  oc adm policy add-scc-to-user anyuid -z default -n serving-tests
+
+  header "Running tests"
+  failed=0
+
+  # Needed because tests assume that istio is found in "istio-system"
+  export GATEWAY_NAMESPACE_OVERRIDE="$SERVICEMESH_NAMESPACE"
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -short -parallel=3 \
+    ./test/e2e \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --resolvabledomain || failed=1
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
+    ./test/conformance/runtime/... \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --resolvabledomain || failed=1
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
+    ./test/conformance/api/... \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --resolvabledomain || failed=1
+
+  return $failed
+}
+
+scale_up_workers || exit 1
+
+failed=0
+(( !failed )) && install_knative || failed=1
+(( !failed )) && run_e2e_tests || failed=1
+(( failed )) && dump_cluster_state
+(( failed )) && exit 1
+
+success

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -86,9 +86,6 @@ function install_knative(){
 
   oc new-project $SERVING_NAMESPACE
 
-  # TODO: master branch will not work this file path. Probably wget is necessary.?
-  oc create configmap ko-data -n $SERVING_NAMESPACE --from-file="openshift/release/knative-serving-ci.yaml"
-
   # Install CatalogSource in OLM namespace
   export IMAGE_QUEUE=${IMAGE_FORMAT//\$\{component\}/knative-serving-queue}
   export IMAGE_activator=${IMAGE_FORMAT//\$\{component\}/knative-serving-activator}
@@ -129,6 +126,9 @@ function deploy_serverless_operator(){
   local name="serverless-operator"
   local operator_ns
   operator_ns=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
+
+  # TODO: master branch will not work this file path. Probably wget is necessary.?
+  oc create configmap ko-data -n $operator_ns --from-file="openshift/release/knative-serving-ci.yaml"
 
   cat <<-EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -86,6 +86,9 @@ function install_knative(){
 
   oc new-project $SERVING_NAMESPACE
 
+  # TODO: master branch will not work this file path. Probably wget is necessary.?
+  oc create configmap ko-data -n $SERVING_NAMESPACE --from-file="openshift/release/knative-serving-ci.yaml"
+
   # Install CatalogSource in OLM namespace
   export IMAGE_QUEUE=${IMAGE_FORMAT//\$\{component\}/knative-serving-queue}
   export IMAGE_activator=${IMAGE_FORMAT//\$\{component\}/knative-serving-activator}

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -149,21 +149,6 @@ function run_e2e_tests(){
   echo ">> Creating test resources for OpenShift (test/config/)"
   oc apply -f test/config
 
-  INGRESS_CLASS=kourier.ingress.networking.knative.dev
-
-  echo ">> Configuring the default Ingress: ${INGRESS_CLASS}"
-  cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-network
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: devel
-data:
-  ingress.class: ${INGRESS_CLASS}
-EOF
-
   oc adm policy add-scc-to-user privileged -z default -n serving-tests
   oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
   # adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
@@ -174,6 +159,7 @@ EOF
 
   export GATEWAY_OVERRIDE=kourier
   export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
+  export INGRESS_CLASS=kourier.ingress.networking.knative.dev
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -short -parallel=3 \

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -7,7 +7,7 @@ source "$(dirname "$0")/release/resolve.sh"
 set -x
 
 readonly SERVING_NAMESPACE=knative-serving
-readonly SERVICEMESH_NAMESPACE=knative-serving-ingress
+readonly SERVING_INGRESS_NAMESPACE=knative-serving-ingress
 
 # A golang template to point the tests to the right image coordinates.
 # {{.Name}} is the name of the image, for example 'autoscale'.
@@ -92,7 +92,6 @@ function install_knative(){
   export IMAGE_autoscaler=${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler}
   export IMAGE_autoscaler_hpa=${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler-hpa}
   export IMAGE_controller=${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}
-  export IMAGE_networking_istio=${IMAGE_FORMAT//\$\{component\}/knative-serving-istio}
   export IMAGE_webhook=${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}
   envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
   timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
@@ -106,7 +105,7 @@ function install_knative(){
 
   # Install Knative Serving
   cat <<-EOF | oc apply -f -
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
 metadata:
   name: knative-serving
@@ -117,8 +116,8 @@ EOF
   timeout 900 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
   wait_until_pods_running $SERVING_NAMESPACE || return 1
 
-  wait_until_service_has_external_ip $SERVICEMESH_NAMESPACE istio-ingressgateway || fail_test "Ingress has no external IP"
-  wait_until_hostname_resolves "$(kubectl get svc -n $SERVICEMESH_NAMESPACE istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+  wait_until_service_has_external_ip $SERVING_INGRESS_NAMESPACE kourier || fail_test "Ingress has no external IP"
+  wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 
   header "Knative Installed successfully"
 }
@@ -144,8 +143,6 @@ EOF
 
 function run_e2e_tests(){
   echo ">> Creating test resources for OpenShift (test/config/)"
-  # Removing unneeded test resources.
-  rm test/config/100-istio-default-domain.yaml
   oc apply -f test/config
 
   oc adm policy add-scc-to-user privileged -z default -n serving-tests
@@ -156,8 +153,8 @@ function run_e2e_tests(){
   header "Running tests"
   failed=0
 
-  # Needed because tests assume that istio is found in "istio-system"
-  export GATEWAY_NAMESPACE_OVERRIDE="$SERVICEMESH_NAMESPACE"
+  export GATEWAY_OVERRIDE=kourier
+  export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
 
   report_go_test \
     -v -tags=e2e -count=1 -timeout=35m -short -parallel=3 \

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -93,7 +93,9 @@ function install_knative(){
   export IMAGE_autoscaler_hpa=${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler-hpa}
   export IMAGE_controller=${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}
   export IMAGE_webhook=${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}
-  export IMAGE_kourier=${IMAGE_FORMAT//\$\{component\}/kourier}
+  # Kourier is not built in this project.
+  # export IMAGE_kourier=${IMAGE_FORMAT//\$\{component\}/kourier}
+  export IMAGE_kourier="quay.io/3scale/kourier:v0.3.11"
   envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
   timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE

--- a/openshift/olm/README.md
+++ b/openshift/olm/README.md
@@ -1,0 +1,49 @@
+
+This is the `CatalogSource` for the [knative-serving-operator](https://github.com/openshift-knative/knative-serving-operator).
+
+WARNING: The `knative-serving` operator refers to some Istio CRD's, so
+either install istio or...
+
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.5.1/istio-crds.yaml
+
+To install this `CatalogSource`:
+
+    OLM=$(kubectl get pods --all-namespaces | grep olm-operator | head -1 | awk '{print $1}')
+    kubectl apply -n $OLM -f https://raw.githubusercontent.com/openshift/knative-serving/release-v0.6.0/openshift/olm/knative-serving.catalogsource.yaml
+
+To install Knative Serving, either use the console, or apply the
+following yaml:
+
+```
+cat <<-EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: knative-serving-operator-sub
+  generateName: knative-serving-operator-
+  namespace: knative-serving
+spec:
+  source: knative-serving-operator
+  sourceNamespace: $OLM
+  name: knative-serving-operator
+  channel: alpha
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+EOF
+```

--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -1,0 +1,29 @@
+diff --git a/openshift/olm/knative-serving.catalogsource.yaml b/openshift/olm/knative-serving.catalogsource.yaml
+index 5af9e00a2..a9da99ee1 100644
+--- a/openshift/olm/knative-serving.catalogsource.yaml
++++ b/openshift/olm/knative-serving.catalogsource.yaml
+@@ -2771,12 +2771,24 @@ data:
+                             fieldPath: metadata.namespace
+                       - name: METRICS_DOMAIN
+                         value: knative.dev/serving-operator
++                      - name: KO_DATA_PATH
++                        value: /tmp/
+                       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                       imagePullPolicy: IfNotPresent
+                       name: knative-serving-operator
+                       ports:
+                       - containerPort: 9090
+                         name: metrics
++                      volumeMounts:
++                      - mountPath: /tmp/knative-serving
++                        name: release-manifest
++                    volumes:
++                    - name: release-manifest
++                      configMap:
++                        name: ko-data
++                        items:
++                        - key: knative-serving-ci.yaml
++                          path: knative-serving-ci.yaml
+                     serviceAccountName: knative-serving-operator
+             - name: knative-serving-openshift
+               spec:

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -1,4 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# NOTE: This knative-serving.catalogsource.yaml is generaed by catalog.sh in serverless-operator.
+#       Then, change image name to adjust for CI script.
+#
+# git clone https://github.com/openshift-knative/serverless-operator.git
+# cd serverless-operator && bash hack/catalog.sh > $OUTFILE
 
 set -e
 
@@ -11,3 +17,4 @@ sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-se
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler-hpa|$\{IMAGE_autoscaler_hpa\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-controller|$\{IMAGE_controller\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-webhook|$\{IMAGE_webhook\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:kourier|$\{IMAGE_kourier\}|g" $OUTFILE

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -18,3 +18,5 @@ sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-se
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-controller|$\{IMAGE_controller\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-webhook|$\{IMAGE_webhook\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:kourier|$\{IMAGE_kourier\}|g" $OUTFILE
+
+git apply config_map.patch

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+VERSION="v0.12.1"
+OUTFILE="knative-serving.catalogsource.yaml"
+
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-queue|$\{IMAGE_QUEUE\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-activator|$\{IMAGE_activator\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler|$\{IMAGE_autoscaler\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler-hpa|$\{IMAGE_autoscaler_hpa\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-controller|$\{IMAGE_controller\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-webhook|$\{IMAGE_webhook\}|g" $OUTFILE

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# NOTE: This knative-serving.catalogsource.yaml is generaed by catalog.sh in serverless-operator.
-#       Then, change image name to adjust for CI script.
+# NOTE:
+# The initial knative-serving.catalogsource.yaml is generaed by catalog.sh in serverless-operator.
+# So you need to run following command before running this script.
 #
 # git clone https://github.com/openshift-knative/serverless-operator.git
 # cd serverless-operator && bash hack/catalog.sh > $OUTFILE

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -2820,6 +2820,8 @@ data:
                             value: "4.3.0"
                           - name: REQUIRED_NAMESPACE
                             value: "knative-serving"
+                          - name: KOURIER_MANIFEST_PATH
+                            value: deploy/resources/kourier/kourier-latest.yaml
                           - name: IMAGE_queue-proxy
                             value: ${IMAGE_QUEUE}
                           - name: IMAGE_activator
@@ -2833,11 +2835,9 @@ data:
                           - name: IMAGE_webhook
                             value: ${IMAGE_webhook}
                           - name: IMAGE_3scale-kourier-gateway
-                            value: docker.io/maistra/proxyv2-ubi8:1.0.4
+                            value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
                             value: ${IMAGE_kourier}
-                          - name: KOURIER_MANIFEST_PATH
-                            value: deploy/resources/kourier/kourier-latest.yaml
             - name: knative-openshift-ingress
               spec:
                 replicas: 1
@@ -2960,7 +2960,7 @@ data:
           - name: IMAGE_3scale-kourier-control
             image: ${IMAGE_kourier}
           - name: IMAGE_3scale-kourier-gateway
-            image: docker.io/maistra/proxyv2-ubi8:1.0.4
+            image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -2836,6 +2836,8 @@ data:
                             value: docker.io/maistra/proxyv2-ubi8:1.0.4
                           - name: IMAGE_3scale-kourier-control
                             value: ${IMAGE_kourier}
+                          - name: KOURIER_MANIFEST_PATH
+                            value: deploy/resources/kourier/kourier-latest.yaml
             - name: knative-openshift-ingress
               spec:
                 replicas: 1

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -1,0 +1,498 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: serverless-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: knativeservings.serving.knative.dev
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.version
+          name: Version
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+          name: Reason
+          type: string
+        group: serving.knative.dev
+        names:
+          kind: KnativeServing
+          listKind: KnativeServingList
+          plural: knativeservings
+          singular: knativeserving
+          shortNames:
+          - ks
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            description: Schema for the knativeservings API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec defines the desired state of KnativeServing
+                properties:
+                  config:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: A means to override the corresponding entries in the upstream
+                      configmaps
+                    type: object
+                type: object
+              status:
+                description: Status defines the observed state of KnativeServing
+                properties:
+                  conditions:
+                    description: The latest available observations of a resource's current
+                      state.
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another. We use VolatileTime
+                            in place of metav1.Time to exclude this from creating equality.Semantic
+                            differences (all other things held constant).
+                          type: string
+                        message:
+                          description: A human readable message indicating details about
+                            the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        severity:
+                          description: Severity with which to treat failures of this type
+                            of condition. When this is not specified, it defaults to Error.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                      required:
+                      - type
+                      - status
+                      type: object
+                    type: array
+                  version:
+                    description: The version of the installed release
+                    type: string
+                type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+  clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "serving.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.2.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.2.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+          # Knative Serving
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+          ## Prerequisites
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+          ## Further Information
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: ${IMAGE_QUEUE}
+                      - name: IMAGE_activator
+                        value: ${IMAGE_activator}
+                      - name: IMAGE_autoscaler
+                        value: ${IMAGE_autoscaler}
+                      - name: IMAGE_autoscaler-hpa
+                        value: ${IMAGE_autoscaler_hpa}
+                      - name: IMAGE_controller
+                        value: ${IMAGE_controller}
+                      - name: IMAGE_networking-istio
+                        value: ${IMAGE_networking_istio}
+                      - name: IMAGE_webhook
+                        value: ${IMAGE_webhook}
+                      image: quay.io/openshift-knative/knative-serving-operator:v0.9.0-1.2.0-05
+                      args:
+                        - --filename=https://raw.githubusercontent.com/openshift/knative-serving/release-next/openshift/release/knative-serving-ci.yaml # remove this from individual release branches
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.1.2
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        version: 1.2.0
+  packages: |-
+    - packageName: serverless-operator
+      channels:
+      - name: techpreview
+        currentCSV: serverless-operator.v1.2.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: serverless-operator
+spec:
+  configMap: serverless-operator
+  displayName: Serverless Operator
+  publisher: Red Hat
+  sourceType: internal

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -2771,12 +2771,24 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
+                      - name: KO_DATA_PATH
+                        value: /tmp/
                       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
                       - containerPort: 9090
                         name: metrics
+                      volumeMounts:
+                      - mountPath: /tmp/knative-serving
+                        name: release-manifest
+                    volumes:
+                    - name: release-manifest
+                      configMap:
+                        name: ko-data
+                        items:
+                        - key: knative-serving-ci.yaml
+                          path: knative-serving-ci.yaml
                     serviceAccountName: knative-serving-operator
             - name: knative-serving-openshift
               spec:

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -184,8 +184,6 @@ data:
           listKind: KnativeServingList
           plural: knativeservings
           singular: knativeserving
-          shortNames:
-          - ks
         scope: Namespaced
         subresources:
           status: {}
@@ -2837,7 +2835,7 @@ data:
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.4
                           - name: IMAGE_3scale-kourier-control
-                            value: quay.io/3scale/kourier:v0.3.10
+                            value: ${IMAGE_kourier}
             - name: knative-openshift-ingress
               spec:
                 replicas: 1
@@ -2957,6 +2955,10 @@ data:
             image: ${IMAGE_controller}
           - name: IMAGE_webhook
             image: ${IMAGE_webhook}
+          - name: IMAGE_3scale-kourier-control
+            image: ${IMAGE_kourier}
+          - name: IMAGE_3scale-kourier-gateway
+            image: docker.io/maistra/proxyv2-ubi8:1.0.4
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -8,6 +8,164 @@ data:
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
       metadata:
+        name: knativeservings.operator.knative.dev
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.version
+          name: Version
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        group: operator.knative.dev
+        names:
+          kind: KnativeServing
+          listKind: KnativeServingList
+          plural: knativeservings
+          shortNames:
+          - ks
+          singular: knativeserving
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            description: Schema for the knativeservings API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec defines the desired state of KnativeServing
+                properties:
+                  cluster-local-gateway:
+                    description: A means to override the cluster-local-gateway
+                    properties:
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: The selector for the ingress-gateway.
+                        type: object
+                    type: object
+                  config:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: A means to override the corresponding entries in the upstream
+                      configmaps
+                    type: object
+                  controller-custom-certs:
+                    description: Enabling the controller to trust registries with self-signed
+                      certificates
+                    properties:
+                      name:
+                        description: The name of the ConfigMap or Secret
+                        type: string
+                      type:
+                        description: One of ConfigMap or Secret
+                        enum:
+                        - ConfigMap
+                        - Secret
+                        - ""
+                        type: string
+                    type: object
+                  knative-ingress-gateway:
+                    description: A means to override the knative-ingress-gateway
+                    properties:
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: The selector for the ingress-gateway.
+                        type: object
+                    type: object
+                  registry:
+                    description: A means to override the corresponding deployment images
+                      in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                    properties:
+                      default:
+                        description: The default image reference template to use for all
+                          knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets to be used when pulling the knative
+                          images. The secret must be created in the same namespace as the
+                          knative-serving deployments, and not the namespace of this resource.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the secret.
+                              type: string
+                          type: object
+                        type: array
+                      override:
+                        additionalProperties:
+                          type: string
+                        description: A map of a container name or image name to the full
+                          image location of the individual knative image.
+                        type: object
+                    type: object
+                type: object
+              status:
+                description: Status defines the observed state of KnativeServing
+                properties:
+                  conditions:
+                    description: The latest available observations of a resource's current
+                      state.
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another. We use VolatileTime
+                            in place of metav1.Time to exclude this from creating equality.Semantic
+                            differences (all other things held constant).
+                          type: string
+                        message:
+                          description: A human readable message indicating details about
+                            the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        severity:
+                          description: Severity with which to treat failures of this type
+                            of condition. When this is not specified, it defaults to Error.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                      required:
+                      - type
+                      - status
+                      type: object
+                    type: array
+                  version:
+                    description: The version of the installed release
+                    type: string
+                type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
         name: knativeservings.serving.knative.dev
       spec:
         additionalPrinterColumns:
@@ -105,6 +263,595 @@ data:
           served: true
           storage: true
   clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"serving.knative.dev/v1alpha1","kind":"KnativeServing","metadata":{"name":"knative-serving"},"spec":{"config":{"autoscaler":{"container-concurrency-target-default":"100","container-concurrency-target-percentage":"1.0","enable-scale-to-zero":"true","max-scale-up-rate":"10","panic-threshold-percentage":"200.0","panic-window":"6s","panic-window-percentage":"10.0","scale-to-zero-grace-period":"30s","stable-window":"60s","tick-interval":"2s"},"defaults":{"revision-cpu-limit":"1000m","revision-cpu-request":"400m","revision-memory-limit":"200M","revision-memory-request":"100M","revision-timeout-seconds":"300"},"deployment":{"registriesSkippingTagResolving":"ko.local,dev.local"},"gc":{"stale-revision-create-delay":"24h","stale-revision-lastpinned-debounce":"5h","stale-revision-minimum-generations":"1","stale-revision-timeout":"15h"},"logging":{"loglevel.activator":"info","loglevel.autoscaler":"info","loglevel.controller":"info","loglevel.queueproxy":"info","loglevel.webhook":"info"},"observability":{"logging.enable-var-log-collection":"false","metrics.backend-destination":"prometheus"},"tracing":{"enable":"false","sample-rate":"0.1"}}}}]'
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.0.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat
+        name: serverless-operator.v1.0.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        description: |
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.7.1
+                      - name: IMAGE_activator
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.7.1
+                      - name: IMAGE_autoscaler
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.7.1
+                      - name: IMAGE_controller
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.7.1
+                      - name: IMAGE_networking-certmanager
+                        value: quay.io/openshift-knative/knative-serving-certmanager:v0.7.1
+                      - name: IMAGE_networking-istio
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.7.1
+                      - name: IMAGE_webhook
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.7.1
+                      image: quay.io/openshift-knative/knative-serving-operator:v0.7.1-TP1-04
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.7
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: knative@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        version: 1.0.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"serving.knative.dev/v1alpha1","kind":"KnativeServing","metadata":{"name":"knative-serving"},"spec":{"config":{"autoscaler":{"container-concurrency-target-default":"100","container-concurrency-target-percentage":"1.0","enable-scale-to-zero":"true","max-scale-up-rate":"10","panic-threshold-percentage":"200.0","panic-window":"6s","panic-window-percentage":"10.0","scale-to-zero-grace-period":"30s","stable-window":"60s","tick-interval":"2s"},"defaults":{"revision-cpu-limit":"1000m","revision-cpu-request":"400m","revision-memory-limit":"200M","revision-memory-request":"100M","revision-timeout-seconds":"300"},"deployment":{"registriesSkippingTagResolving":"ko.local,dev.local"},"gc":{"stale-revision-create-delay":"24h","stale-revision-lastpinned-debounce":"5h","stale-revision-minimum-generations":"1","stale-revision-timeout":"15h"},"logging":{"loglevel.activator":"info","loglevel.autoscaler":"info","loglevel.controller":"info","loglevel.queueproxy":"info","loglevel.webhook":"info"},"observability":{"logging.enable-var-log-collection":"false","metrics.backend-destination":"prometheus"},"tracing":{"enable":"false","sample-rate":"0.1"}}}}]'
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.1.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.1.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        description: |
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.8.1
+                      - name: IMAGE_activator
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.8.1
+                      - name: IMAGE_autoscaler
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.8.1
+                      - name: IMAGE_autoscaler-hpa
+                        value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.8.1
+                      - name: IMAGE_controller
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.8.1
+                      - name: IMAGE_networking-istio
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.8.1
+                      - name: IMAGE_webhook
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.8.1
+                      image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-05
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.9
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        replaces: serverless-operator.v1.0.0
+        version: 1.1.0
     - apiVersion: operators.coreos.com/v1alpha1
       kind: ClusterServiceVersion
       metadata:
@@ -210,30 +957,39 @@ data:
         description: |-
           The Red Hat Serverless Operator provides a collection of API's to
           install various "serverless" services.
+
           This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
           # Knative Serving
+
           Knative Serving builds on Kubernetes to support deploying and
           serving of serverless applications and functions. Serving is easy
           to get started with and scales to support advanced scenarios. The
           Knative Serving project provides middleware primitives that
           enable:
+
           - Rapid deployment of serverless containers
           - Automatic scaling up and down to zero
           - Routing and network programming for Istio components
           - Point-in-time snapshots of deployed code and configurations
+
           ## Prerequisites
+
           The Serverless Operator's provided APIs such as Knative Serving
           have certain requirements with regards to the size of the underlying
           cluster and a working installation of Service Mesh. See the [installation
-          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#installing-openshift-serverless)
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
           of the Serverless documentation for more info.
+
           ## Further Information
+
           For documentation on using Knative Serving, see the
-          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
-          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
         displayName: OpenShift Serverless Operator
         icon:
-        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
           mediatype: image/svg+xml
         install:
           spec:
@@ -354,22 +1110,20 @@ data:
                       - name: OPERATOR_NAME
                         value: knative-serving-operator
                       - name: IMAGE_QUEUE
-                        value: ${IMAGE_QUEUE}
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.9.0
                       - name: IMAGE_activator
-                        value: ${IMAGE_activator}
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.9.0
                       - name: IMAGE_autoscaler
-                        value: ${IMAGE_autoscaler}
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.9.0
                       - name: IMAGE_autoscaler-hpa
-                        value: ${IMAGE_autoscaler_hpa}
+                        value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.9.0
                       - name: IMAGE_controller
-                        value: ${IMAGE_controller}
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.9.0
                       - name: IMAGE_networking-istio
-                        value: ${IMAGE_networking_istio}
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.9.0
                       - name: IMAGE_webhook
-                        value: ${IMAGE_webhook}
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.9.0
                       image: quay.io/openshift-knative/knative-serving-operator:v0.9.0-1.2.0-05
-                      args:
-                        - --filename=https://raw.githubusercontent.com/openshift/knative-serving/release-next/openshift/release/knative-serving-ci.yaml # remove this from individual release branches
                       imagePullPolicy: Always
                       name: knative-serving-operator
                       resources: {}
@@ -388,7 +1142,7 @@ data:
                     serviceAccountName: knative-openshift-ingress
                     containers:
                       - name: knative-openshift-ingress
-                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.1.2
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.13
                         command:
                         - knative-openshift-ingress
                         imagePullPolicy: Always
@@ -471,7 +1225,7 @@ data:
         - serving
         links:
         - name: Documentation
-          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
         - name: Source Repository
           url: https://github.com/openshift-knative/serverless-operator
         maintainers:
@@ -480,12 +1234,1728 @@ data:
         maturity: alpha
         provider:
           name: Red Hat, Inc.
+        replaces: serverless-operator.v1.1.0
         version: 1.2.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "serving.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.3.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.3.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        minKubeVersion: 1.14.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-queue
+                      - name: IMAGE_activator
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-activator
+                      - name: IMAGE_autoscaler
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-autoscaler
+                      - name: IMAGE_autoscaler-hpa
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-autoscaler-hpa
+                      - name: IMAGE_controller
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-controller
+                      - name: IMAGE_networking-istio
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-istio
+                      - name: IMAGE_webhook
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-webhook
+                      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.3.0:knative-serving-operator
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.3.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        replaces: serverless-operator.v1.2.0
+        version: 1.3.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.4.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.4.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving (obsolete)
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        minKubeVersion: 1.14.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.1.13"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+                          - name: IMAGE_networking-istio
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+          - name: IMAGE_networking-istio
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+        replaces: serverless-operator.v1.3.0
+        version: 1.4.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.4.1
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.4.1
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving (obsolete)
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        minKubeVersion: 1.14.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.1.13"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+                          - name: IMAGE_networking-istio
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+          - name: IMAGE_networking-istio
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+        replaces: serverless-operator.v1.4.0
+        version: 1.4.1
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.5.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.5.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving (obsolete)
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+        minKubeVersion: 1.15.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.3.0"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: IMAGE_queue-proxy
+                            value: ${IMAGE_QUEUE}
+                          - name: IMAGE_activator
+                            value: ${IMAGE_activator}
+                          - name: IMAGE_autoscaler
+                            value: ${IMAGE_autoscaler}
+                          - name: IMAGE_autoscaler-hpa
+                            value: ${IMAGE_autoscaler}-hpa
+                          - name: IMAGE_controller
+                            value: ${IMAGE_controller}
+                          - name: IMAGE_webhook
+                            value: ${IMAGE_webhook}
+                          - name: IMAGE_3scale-kourier-gateway
+                            value: docker.io/maistra/proxyv2-ubi8:1.0.4
+                          - name: IMAGE_3scale-kourier-control
+                            value: quay.io/3scale/kourier:v0.3.10
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: ${IMAGE_QUEUE}
+          - name: IMAGE_activator
+            image: ${IMAGE_activator}
+          - name: IMAGE_autoscaler
+            image: ${IMAGE_autoscaler}
+          - name: IMAGE_autoscaler-hpa
+            image: ${IMAGE_autoscaler}-hpa
+          - name: IMAGE_controller
+            image: ${IMAGE_controller}
+          - name: IMAGE_webhook
+            image: ${IMAGE_webhook}
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+        replaces: serverless-operator.v1.4.1
+        version: 1.5.0
   packages: |-
     - packageName: serverless-operator
       channels:
       - name: techpreview
-        currentCSV: serverless-operator.v1.2.0
+        currentCSV: serverless-operator.v1.5.0
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource

--- a/openshift/patches/003-routeretry.patch
+++ b/openshift/patches/003-routeretry.patch
@@ -1,0 +1,80 @@
+diff --git a/test/v1/route.go b/test/v1/route.go
+index 11026ffdc..b48db35f6 100644
+--- a/test/v1/route.go
++++ b/test/v1/route.go
+@@ -19,6 +19,7 @@ package v1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
+@@ -115,8 +116,13 @@ func IsRouteNotReady(r *v1.Route) (bool, error) {
+ }
+ 
+ // RetryingRouteInconsistency retries common requests seen when creating a new route
++// - 404 until the route is propagated to the proxy
++// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
+ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+ 	return func(resp *spoof.Response) (bool, error) {
++		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}
+diff --git a/test/v1alpha1/route.go b/test/v1alpha1/route.go
+index 87406b63e..ce6e6cc86 100644
+--- a/test/v1alpha1/route.go
++++ b/test/v1alpha1/route.go
+@@ -21,6 +21,7 @@ package v1alpha1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
+@@ -50,10 +51,14 @@ func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, f
+ }
+ 
+ // RetryingRouteInconsistency retries common requests seen when creating a new route
+-// TODO(5573): Remove this.
++// - 404 until the route is propagated to the proxy
++// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
+ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+ 	return func(resp *spoof.Response) (bool, error) {
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
++		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
++			return false, nil
++		}
+ 		return innerCheck(resp)
+ 	}
+ }
+diff --git a/test/v1beta1/route.go b/test/v1beta1/route.go
+index 119b4a818..1cbc802cb 100644
+--- a/test/v1beta1/route.go
++++ b/test/v1beta1/route.go
+@@ -19,6 +19,7 @@ package v1beta1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
+@@ -116,8 +117,13 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
+ }
+ 
+ // RetryingRouteInconsistency retries common requests seen when creating a new route
++// - 404 until the route is propagated to the proxy
++// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
+ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+ 	return func(resp *spoof.Response) (bool, error) {
++		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}

--- a/openshift/patches/004-grpc.patch
+++ b/openshift/patches/004-grpc.patch
@@ -1,0 +1,27 @@
+diff --git a/test/e2e/grpc_test.go b/test/e2e/grpc_test.go
+index a358b354c..5676d6b66 100644
+--- a/test/e2e/grpc_test.go
++++ b/test/e2e/grpc_test.go
+@@ -152,6 +152,7 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
+ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
+ 	t.Helper()
+ 	t.Parallel()
++	resolvable := false
+ 	cancel := logstream.Start(t)
+ 	defer cancel()
+ 
+@@ -181,12 +182,12 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
+ 		url,
+ 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+ 		"gRPCPingReadyToServe",
+-		test.ServingFlags.ResolvableDomain); err != nil {
++		resolvable); err != nil {
+ 		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
+ 	}
+ 
+ 	host := url.Host
+-	if !test.ServingFlags.ResolvableDomain {
++	if !resolvable {
+ 		host = pkgTest.Flags.IngressEndpoint
+ 		if pkgTest.Flags.IngressEndpoint == "" {
+ 			host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)

--- a/openshift/patches/005-disablehpa.patch
+++ b/openshift/patches/005-disablehpa.patch
@@ -1,0 +1,20 @@
+diff --git a/test/e2e/autoscale_test.go b/test/e2e/autoscale_test.go
+index e385327ad..2b8edccd6 100644
+--- a/test/e2e/autoscale_test.go
++++ b/test/e2e/autoscale_test.go
+@@ -366,7 +366,6 @@ func TestAutoscaleUpCountPods(t *testing.T) {
+ 	t.Parallel()
+ 
+ 	classes := map[string]string{
+-		"hpa": autoscaling.HPA,
+ 		"kpa": autoscaling.KPA,
+ 	}
+ 
+@@ -399,7 +398,6 @@ func TestRPSBasedAutoscaleUpCountPods(t *testing.T) {
+ 	t.Parallel()
+ 
+ 	classes := map[string]string{
+-		"hpa": autoscaling.HPA,
+ 		"kpa": autoscaling.KPA,
+ 	}
+ 

--- a/openshift/productization/dist-git/.gitkeep
+++ b/openshift/productization/dist-git/.gitkeep
@@ -1,0 +1,1 @@
+This file serves as a placeholder to ensure this directory is not removed by git.

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -1,0 +1,19 @@
+FROM rhel8/go-toolset:1.13.4 AS builder
+WORKDIR /opt/app-root/src/go/src/knative.dev/$COMPONENT
+COPY . .
+ENV GOFLAGS="-mod=vendor"
+RUN go build -o /tmp/$SUBCOMPONENT ./cmd/$GO_PACKAGE
+
+FROM ubi8-minimal:8-released
+COPY --from=builder /tmp/$SUBCOMPONENT /ko-app/$SUBCOMPONENT
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-tech-preview-$COMPONENT-$SUBCOMPONENT-rhel8-container" \
+      name="openshift-serverless-1-tech-preview/$COMPONENT-$SUBCOMPONENT-rhel8" \
+      version="$VERSION" \
+      summary="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 $CAPITALIZED_COMPONENT $CAPITALIZED_SUBCOMPONENT"
+
+ENTRYPOINT ["/ko-app/$SUBCOMPONENT"]

--- a/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
+++ b/openshift/productization/generate-dockerfiles/gen_dockerfiles.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -x
+
+target_dir=$1
+
+component=Serving
+
+for subcomponent in Activator Autoscaler Autoscaler-HPA Controller \
+                    Networking-Istio Networking-CertManager Networking-NSCert \
+                    Queue Webhook; \
+do
+    export CAPITALIZED_COMPONENT=$component
+    export CAPITALIZED_SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/-/ /g')
+    export COMPONENT=$(echo -e "$component" | sed -e 's/\(.*\)/\L\1/g')
+    export SUBCOMPONENT=$(echo -e "$subcomponent" | sed -e 's/\(.*\)/\L\1/g')
+    export VERSION=$(git rev-parse --abbrev-ref HEAD | sed -r 's/release-//g')
+    export GO_PACKAGE=$(echo -e "$SUBCOMPONENT" | sed -e 's/networking-/networking\//g')
+    envsubst \
+      < openshift/productization/generate-dockerfiles/Dockerfile.in \
+      > ${target_dir}/Dockerfile.$SUBCOMPONENT
+done

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -1,0 +1,35 @@
+# Release creation
+
+## Branching
+
+As far as branching goes, we have two use-cases:
+
+1. Creating a branch based off an upstream release tag.
+2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
+
+A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
+that points to the upstream repository and a remote "openshift" that points to the openshift fork.
+
+Run the scripts from the root of the repository.
+
+### Creating a branch based off an upstream release tag
+
+To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
+
+```bash
+$ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
+```
+
+This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
+files that we need to run CI on top of it.
+
+### Updating the release-next branch that follow upstream's HEAD
+
+To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
+
+```bash
+$ ./openshift/release/update-to-head.sh
+```
+
+That will pull the latest master from upstream, rebase the current fixes on the release-next branch
+on top of it, update the Openshift specific files if necessary, and then trigger CI.

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+# Usage: create-release-branch.sh v0.4.1 release-v0.4.1
+
+release=$1
+target=$2
+release_regexp="^release-v([0-9]+\.)+([0-9])$"
+
+if [[ ! $target =~ $release_regexp ]]; then
+    echo "\"$target\" is wrong format. Must have proper format like release-v0.1.2"
+    exit 1
+fi
+
+# Fetch the latest tags and checkout a new branch from the wanted tag.
+git fetch upstream --tags
+git checkout -b "$target" "$release"
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+make generate-dockerfiles
+make generate-p12n-dockerfiles
+make RELEASE=$release generate-release
+make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+git commit -m "Add openshift specific files."

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/resolve.sh
+
+release=$1
+output_file="openshift/release/knative-serving-${release}.yaml"
+
+if [ "$release" = "ci" ]; then
+    image_prefix="image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-"
+    tag=""
+else
+    image_prefix="quay.io/openshift-knative/knative-serving-"
+    tag=$release
+fi
+
+resolve_resources config/ "$output_file" "$image_prefix" "$tag"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -717,7 +717,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 spec:
-  image: ko://knative.dev/serving/cmd/queue
+  image: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-queue
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -763,7 +763,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: activator
-        image: ko://knative.dev/serving/cmd/activator
+        image: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-activator
         resources:
           requests:
             cpu: 300m
@@ -861,7 +861,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: autoscaler-hpa
-        image: ko://knative.dev/serving/cmd/autoscaler-hpa
+        image: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-autoscaler-hpa
         resources:
           requests:
             cpu: 30m
@@ -931,7 +931,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: autoscaler
-        image: ko://knative.dev/serving/cmd/autoscaler
+        image: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-autoscaler
         resources:
           requests:
             cpu: 30m
@@ -1038,7 +1038,6 @@ data:
     revision-memory-limit: "200M"  # 200 megabytes of memory
     container-name-template: "user-container"
     container-concurrency: "0"
-    container-concurrency-max-limit: "1000"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1048,7 +1047,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 data:
-  queueSidecarImage: ko://knative.dev/serving/cmd/queue
+  queueSidecarImage: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-queue
   _example: |
     registriesSkippingTagResolving: "ko.local,dev.local"
 ---
@@ -1211,7 +1210,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: controller
-        image: ko://knative.dev/serving/cmd/controller
+        image: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-controller
         resources:
           requests:
             cpu: 100m
@@ -1274,252 +1273,6 @@ spec:
   groupPriorityMinimum: 100
   versionPriority: 100
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: knative-serving-istio
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-    serving.knative.dev/controller: "true"
-    networking.knative.dev/ingress-provider: istio
-rules:
-- apiGroups: ["networking.istio.io"]
-  resources: ["virtualservices", "gateways"]
-  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
----
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: knative-ingress-gateway
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-    networking.knative.dev/ingress-provider: istio
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "*"
----
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: cluster-local-gateway
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-    networking.knative.dev/ingress-provider: istio
-spec:
-  selector:
-    istio: cluster-local-gateway
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "*"
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: config.webhook.istio.networking.internal.knative.dev
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-webhooks:
-- admissionReviewVersions:
-  - v1beta1
-  clientConfig:
-    service:
-      name: istio-webhook
-      namespace: knative-serving
-  failurePolicy: Fail
-  sideEffects: None
-  name: config.webhook.istio.networking.internal.knative.dev
-  namespaceSelector:
-    matchExpressions:
-    - key: serving.knative.dev/release
-      operator: Exists
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: webhook.istio.networking.internal.knative.dev
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-webhooks:
-- admissionReviewVersions:
-  - v1beta1
-  clientConfig:
-    service:
-      name: istio-webhook
-      namespace: knative-serving
-  failurePolicy: Fail
-  sideEffects: None
-  objectSelector:
-    matchExpressions:
-    - {key: "serving.knative.dev/configuration", operator: Exists}
-  name: webhook.istio.networking.internal.knative.dev
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: istio-webhook-certs
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-istio
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-    networking.knative.dev/ingress-provider: istio
-data:
-  _example: |
-    gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
-    local-gateway.knative-serving.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
-    local-gateway.mesh: "mesh"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: networking-istio
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-    networking.knative.dev/ingress-provider: istio
-spec:
-  selector:
-    matchLabels:
-      app: networking-istio
-  template:
-    metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: networking-istio
-        serving.knative.dev/release: "v20200309-53bb214"
-    spec:
-      serviceAccountName: controller
-      containers:
-      - name: networking-istio
-        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:05d7cc822ee4732feff8b9b1ce73de34fbd4a923c5ed5d96feceeb0b42e2723c
-        resources:
-          requests:
-            cpu: 30m
-            memory: 40Mi
-          limits:
-            cpu: 300m
-            memory: 400Mi
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
-          name: METRICS_DOMAIN
-          value: knative.dev/net-istio
-        securityContext:
-          allowPrivilegeEscalation: false
-        ports:
-        - name: metrics
-          containerPort: 9090
-        - name: profiling
-          containerPort: 8008
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istio-webhook
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v20200309-53bb214"
-spec:
-  selector:
-    matchLabels:
-      app: istio-webhook
-      role: istio-webhook
-  template:
-    metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-      labels:
-        app: istio-webhook
-        role: istio-webhook
-        serving.knative.dev/release: "v20200309-53bb214"
-    spec:
-      serviceAccountName: controller
-      containers:
-      - name: webhook
-        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:62f52c1514f840d3cc1f54c0ea6184b8870d431a9c079c6b7bf48108a6d1fde9
-        resources:
-          requests:
-            cpu: 20m
-            memory: 20Mi
-          limits:
-            cpu: 200m
-            memory: 200Mi
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: config-logging
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: config-observability
-        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
-          name: METRICS_DOMAIN
-          value: knative.dev/net-istio
-        - name: WEBHOOK_NAME
-          value: istio-webhook
-        securityContext:
-          allowPrivilegeEscalation: false
-        ports:
-        - name: metrics
-          containerPort: 9090
-        - name: profiling
-          containerPort: 8008
-        - name: https-webhook
-          containerPort: 8443
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-webhook
-  namespace: knative-serving
-  labels:
-    role: istio-webhook
-    serving.knative.dev/release: "v20200309-53bb214"
-spec:
-  ports:
-  - # Define metrics and profiling for them to be accessible within service meshes.
-    name: http-metrics
-    port: 9090
-    targetPort: 9090
-  - name: http-profiling
-    port: 8008
-    targetPort: 8008
-  - name: https-webhook
-    port: 443
-    targetPort: 8443
-  selector:
-    app: istio-webhook
----
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1544,7 +1297,7 @@ spec:
       serviceAccountName: controller
       containers:
       - name: webhook
-        image: ko://knative.dev/serving/cmd/webhook
+        image: image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-webhook
         resources:
           requests:
             cpu: 20m

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -1,0 +1,1596 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    istio-injection: enabled
+    serving.knative.dev/release: devel
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-addressable-resolver
+  labels:
+    serving.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-server-resources
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+rules:
+  - apiGroups: ["custom.metrics.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-core
+  labels:
+    serving.knative.dev/release: devel
+    serving.knative.dev/controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
+    verbs: ["create"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["serving.knative.dev", "autoscaling.internal.knative.dev", "networking.internal.knative.dev"]
+    resources: ["*", "*/status", "*/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+  - apiGroups: ["caching.internal.knative.dev"]
+    resources: ["images"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-podspecable-binding
+  labels:
+    serving.knative.dev/release: devel
+    duck.knative.dev/podspecable: "true"
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - configurations
+  - services
+  verbs:
+  - list
+  - watch
+  - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-admin
+  labels:
+    serving.knative.dev/release: devel
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      serving.knative.dev/controller: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-controller-admin
+  labels:
+    serving.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics:system:auth-delegator
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-custom-metrics
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: custom-metrics-auth-reader
+  namespace: kube-system
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kcert
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - config
+    - cfg
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: Ingress
+    plural: ingresses
+    singular: ingress
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kingress
+    - king
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Metric
+    plural: metrics
+    singular: metric
+    categories:
+    - knative-internal
+    - autoscaling
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: PodAutoscaler
+    plural: podautoscalers
+    singular: podautoscaler
+    categories:
+    - knative-internal
+    - autoscaling
+    shortNames:
+    - kpa
+    - pa
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: DesiredScale
+    type: integer
+    JSONPath: ".status.desiredScale"
+  - name: ActualScale
+    type: integer
+    JSONPath: ".status.actualScale"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rev
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: Config Name
+    type: string
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+  - name: K8s Service Name
+    type: string
+    JSONPath: ".status.serviceName"
+  - name: Generation
+    type: string # int in string form :(
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rt
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - kservice
+    - ksvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - sks
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Mode
+    type: string
+    JSONPath: ".spec.mode"
+  - name: ServiceName
+    type: string
+    JSONPath: ".status.serviceName"
+  - name: PrivateServiceName
+    type: string
+    JSONPath: ".status.privateServiceName"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: config.webhook.serving.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: webhook.serving.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: validation.webhook.serving.knative.dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+---
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  name: queue-proxy
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  image: ko://knative.dev/serving/cmd/queue
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  minReplicas: 1
+  maxReplicas: 20
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: activator
+      role: activator
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: activator
+        role: activator
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: activator
+        image: ko://knative.dev/serving/cmd/activator
+        resources:
+          requests:
+            cpu: 300m
+            memory: 60Mi
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+        env:
+        - name: GOGC
+          value: "500"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: http1
+          containerPort: 8012
+        - name: h2c
+          containerPort: 8013
+        readinessProbe: &probe
+          httpGet:
+            port: 8012
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "activator"
+        livenessProbe: *probe
+      terminationGracePeriodSeconds: 300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: activator-service
+  namespace: knative-serving
+  labels:
+    app: activator
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    app: activator
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: http
+    port: 80
+    targetPort: 8012
+  - name: http2
+    port: 81
+    targetPort: 8013
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler-hpa
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/autoscaler-provider: hpa
+spec:
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: autoscaler-hpa
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler-hpa
+        image: ko://knative.dev/serving/cmd/autoscaler-hpa
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler-hpa
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/autoscaler-provider: hpa
+  name: autoscaler-hpa
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: autoscaler-hpa
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: autoscaler
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler
+        image: ko://knative.dev/serving/cmd/autoscaler
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: websocket
+          containerPort: 8080
+        - name: custom-metrics
+          containerPort: 8443
+        readinessProbe: &probe
+          httpGet:
+            port: 8080
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "autoscaler"
+        livenessProbe: *probe
+        args:
+        - "--secure-port=8443"
+        - "--cert-dir=/tmp"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler
+    serving.knative.dev/release: devel
+  name: autoscaler
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: http
+    port: 8080
+    targetPort: 8080
+  - name: https-custom-metrics
+    port: 443
+    targetPort: 8443
+  selector:
+    app: autoscaler
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    container-concurrency-target-percentage: "70"
+    container-concurrency-target-default: "100"
+    requests-per-second-target-default: "200"
+    target-burst-capacity: "200"
+    stable-window: "60s"
+    panic-window-percentage: "10.0"
+    panic-threshold-percentage: "200.0"
+    max-scale-up-rate: "1000.0"
+    max-scale-down-rate: "2.0"
+    enable-scale-to-zero: "true"
+    tick-interval: "2s"
+    scale-to-zero-grace-period: "30s"
+    enable-graceful-scaledown: "false"
+    pod-autoscaler-class: "kpa.autoscaling.knative.dev"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    revision-timeout-seconds: "300"  # 5 minutes
+    max-revision-timeout-seconds: "600"  # 10 minutes
+    revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+    revision-memory-request: "100M"  # 100 megabytes of memory
+    revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+    revision-memory-limit: "200M"  # 200 megabytes of memory
+    container-name-template: "user-container"
+    container-concurrency: "0"
+    container-concurrency-max-limit: "1000"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-deployment
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  queueSidecarImage: ko://knative.dev/serving/cmd/queue
+  _example: |
+    registriesSkippingTagResolving: "ko.local,dev.local"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    example.com: |
+    example.org: |
+      selector:
+        app: nonprofit
+    svc.cluster.local: |
+      selector:
+        app: secret
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gc
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    stale-revision-create-delay: "48h"
+    stale-revision-timeout: "15h"
+    stale-revision-minimum-generations: "20"
+    stale-revision-lastpinned-debounce: "5h"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    resourceLock: "leases"
+    leaseDuration: "15s"
+    renewDeadline: "10s"
+    retryPeriod: "2s"
+    enabledComponents: "controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    ingress.class: "istio.ingress.networking.knative.dev"
+    certificate.class: "cert-manager.certificate.networking.knative.dev"
+    domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+    tagTemplate: "{{.Tag}}-{{.Name}}"
+    autoTLS: "Disabled"
+    httpProtocol: "Enabled"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    logging.enable-var-log-collection: "false"
+    logging.revision-url-template: |
+      http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+    logging.enable-probe-request-log: "false"
+    metrics.backend-destination: prometheus
+    metrics.request-metrics-backend-destination: prometheus
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    metrics.allow-stackdriver-custom-metrics: "false"
+    profiling.enable: "false"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+data:
+  _example: |
+    backend: "none"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+    stackdriver-project-id: "my-project"
+    debug: "false"
+    sample-rate: "0.1"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: controller
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: controller
+        image: ko://knative.dev/serving/cmd/controller
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+    serving.knative.dev/release: devel
+  name: controller
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: controller
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+spec:
+  service:
+    name: autoscaler
+    namespace: knative-serving
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-istio
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+    serving.knative.dev/controller: "true"
+    networking.knative.dev/ingress-provider: istio
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["virtualservices", "gateways"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: knative-ingress-gateway
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: cluster-local-gateway
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    istio: cluster-local-gateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.istio.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: config.webhook.istio.networking.internal.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.istio.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - {key: "serving.knative.dev/configuration", operator: Exists}
+  name: webhook.istio.networking.internal.knative.dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-istio
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+    networking.knative.dev/ingress-provider: istio
+data:
+  _example: |
+    gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+    local-gateway.knative-serving.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+    local-gateway.mesh: "mesh"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: networking-istio
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    matchLabels:
+      app: networking-istio
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: networking-istio
+        serving.knative.dev/release: "v20200309-53bb214"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: networking-istio
+        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:05d7cc822ee4732feff8b9b1ce73de34fbd4a923c5ed5d96feceeb0b42e2723c
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/net-istio
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v20200309-53bb214"
+spec:
+  selector:
+    matchLabels:
+      app: istio-webhook
+      role: istio-webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: istio-webhook
+        role: istio-webhook
+        serving.knative.dev/release: "v20200309-53bb214"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: webhook
+        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:62f52c1514f840d3cc1f54c0ea6184b8870d431a9c079c6b7bf48108a6d1fde9
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/net-istio
+        - name: WEBHOOK_NAME
+          value: istio-webhook
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-webhook
+  namespace: knative-serving
+  labels:
+    role: istio-webhook
+    serving.knative.dev/release: "v20200309-53bb214"
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app: istio-webhook
+---
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: webhook
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: webhook
+        role: webhook
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: webhook
+        image: ko://knative.dev/serving/cmd/webhook
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: webhook
+    serving.knative.dev/release: devel
+  name: webhook
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    role: webhook

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -1145,7 +1145,6 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 data:
-  ingress.class: "kourier.ingress.networking.knative.dev"
   _example: |
     ingress.class: "istio.ingress.networking.knative.dev"
     certificate.class: "cert-manager.certificate.networking.knative.dev"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -1145,6 +1145,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 data:
+  ingress.class: "kourier.ingress.networking.knative.dev"
   _example: |
     ingress.class: "istio.ingress.networking.knative.dev"
     certificate.class: "cert-manager.certificate.networking.knative.dev"

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+function resolve_resources(){
+  local dir=$1
+  local resolved_file_name=$2
+  local image_prefix=$3
+  local image_tag=$4
+
+  [[ -n $image_tag ]] && image_tag=":$image_tag"
+
+  echo "Writing resolved yaml to $resolved_file_name"
+
+  > "$resolved_file_name"
+
+  for yaml in "$dir"/*.yaml; do
+    resolve_file "$yaml" "$resolved_file_name" "$image_prefix" "$image_tag"
+  done
+}
+
+function resolve_file() {
+  local file=$1
+  local to=$2
+  local image_prefix=$3
+  local image_tag=$4
+
+  # Skip cert-manager, it's not part of upstream's release YAML either.
+  if grep -q 'networking.knative.dev/certificate-provider: cert-manager' "$1"; then
+    return
+  fi
+
+  # Skip nscert, it's not part of upstream's release YAML either.
+  if grep -q 'networking.knative.dev/wildcard-certificate-provider: nscert' "$1"; then
+    return
+  fi
+
+  echo "---" >> "$to"
+  # 1. Rewrite image references
+  # 2. Update config map entry
+  # 3. Remove comment lines
+  # 4. Remove empty lines
+  sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
+      -e "s+\(.* queueSidecarImage: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
+      -e '/^[ \t]*#/d' \
+      -e '/^[ \t]*$/d' \
+      "$file" >> "$to"
+}

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -33,6 +33,11 @@ function resolve_file() {
     return
   fi
 
+  # Skip istio resources, as we use kourier.
+  if grep -q 'networking.knative.dev/ingress-provider: istio' "$1"; then
+    return
+  fi
+
   echo "---" >> "$to"
   # 1. Rewrite image references
   # 2. Update config map entry

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
+
+set -e
+REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+
+# Reset release-next to upstream/master.
+git fetch upstream master
+git checkout upstream/master -B release-next
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+make generate-dockerfiles
+make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+git commit -m ":open_file_folder: Update openshift specific files."
+
+# Apply patches .
+git apply openshift/patches/*
+git commit -am ":fire: Apply carried patches."
+
+git push -f openshift release-next
+
+# Trigger CI
+git checkout release-next -B release-next-ci
+date > ci
+git add ci
+git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/master"
+git push -f openshift release-next-ci
+
+if hash hub 2>/dev/null; then
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+else
+   echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
+fi

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -476,7 +476,6 @@ func TestAutoscaleUpCountPods(t *testing.T) {
 	t.Parallel()
 
 	classes := map[string]string{
-		"hpa": autoscaling.HPA,
 		"kpa": autoscaling.KPA,
 	}
 
@@ -509,7 +508,6 @@ func TestRPSBasedAutoscaleUpCountPods(t *testing.T) {
 	t.Parallel()
 
 	classes := map[string]string{
-		"hpa": autoscaling.HPA,
 		"kpa": autoscaling.KPA,
 	}
 

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -323,6 +323,7 @@ func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test
 func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Helper()
 	t.Parallel()
+	resolvable := false
 	cancel := logstream.Start(t)
 	defer cancel()
 
@@ -354,12 +355,12 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		url,
 		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"gRPCPingReadyToServe",
-		test.ServingFlags.ResolvableDomain); err != nil {
+		resolvable); err != nil {
 		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
 	}
 
 	host := url.Host
-	if !test.ServingFlags.ResolvableDomain {
+	if !resolvable {
 		host = pkgTest.Flags.IngressEndpoint
 		if pkgTest.Flags.IngressEndpoint == "" {
 			host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -115,8 +116,13 @@ func IsRouteNotReady(r *v1.Route) (bool, error) {
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
+// - 404 until the route is propagated to the proxy
+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			return false, nil
+		}
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,10 +51,14 @@ func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, f
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
-// TODO(5573): Remove this.
+// - 404 until the route is propagated to the proxy
+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			return false, nil
+		}
 		return innerCheck(resp)
 	}
 }

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -116,8 +117,13 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
+// - 404 until the route is propagated to the proxy
+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
 	return func(resp *spoof.Response) (bool, error) {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			return false, nil
+		}
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}


### PR DESCRIPTION
As per title, this tries to start testing with Kourier

/hold