### PR TITLE
Bump servleress-operator to v1.5.0 and remove istio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/istio ./cmd/networking/certmanager ./cmd/networking/nscert
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/certmanager ./cmd/networking/nscert
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
 
 install:

--- a/openshift/ci-operator/knative-images/istio/Dockerfile
+++ b/openshift/ci-operator/knative-images/istio/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
-USER 65532
-
-ADD istio /ko-app/istio
-ENTRYPOINT ["/ko-app/istio"]

--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -1,0 +1,29 @@
+diff --git a/openshift/olm/knative-serving.catalogsource.yaml b/openshift/olm/knative-serving.catalogsource.yaml
+index 5af9e00a2..a9da99ee1 100644
+--- a/openshift/olm/knative-serving.catalogsource.yaml
++++ b/openshift/olm/knative-serving.catalogsource.yaml
+@@ -2771,12 +2771,24 @@ data:
+                             fieldPath: metadata.namespace
+                       - name: METRICS_DOMAIN
+                         value: knative.dev/serving-operator
++                      - name: KO_DATA_PATH
++                        value: /tmp/
+                       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                       imagePullPolicy: IfNotPresent
+                       name: knative-serving-operator
+                       ports:
+                       - containerPort: 9090
+                         name: metrics
++                      volumeMounts:
++                      - mountPath: /tmp/knative-serving
++                        name: release-manifest
++                    volumes:
++                    - name: release-manifest
++                      configMap:
++                        name: ko-data
++                        items:
++                        - key: knative-serving-ci.yaml
++                          path: knative-serving-ci.yaml
+                     serviceAccountName: knative-serving-operator
+             - name: knative-serving-openshift
+               spec:

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# NOTE:
+# The initial knative-serving.catalogsource.yaml is generaed by catalog.sh in serverless-operator.
+# So you need to run following command before running this script.
+#
+# git clone https://github.com/openshift-knative/serverless-operator.git
+# cd serverless-operator && bash hack/catalog.sh > $OUTFILE
+
+set -e
+
+VERSION="v0.12.1"
+OUTFILE="knative-serving.catalogsource.yaml"
+
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-queue|$\{IMAGE_QUEUE\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-activator|$\{IMAGE_activator\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler|$\{IMAGE_autoscaler\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler-hpa|$\{IMAGE_autoscaler_hpa\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-controller|$\{IMAGE_controller\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-webhook|$\{IMAGE_webhook\}|g" $OUTFILE
+sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:kourier|$\{IMAGE_kourier\}|g" $OUTFILE
+
+git apply config_map.patch

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -8,6 +8,164 @@ data:
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
       metadata:
+        name: knativeservings.operator.knative.dev
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.version
+          name: Version
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        group: operator.knative.dev
+        names:
+          kind: KnativeServing
+          listKind: KnativeServingList
+          plural: knativeservings
+          shortNames:
+          - ks
+          singular: knativeserving
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            description: Schema for the knativeservings API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec defines the desired state of KnativeServing
+                properties:
+                  cluster-local-gateway:
+                    description: A means to override the cluster-local-gateway
+                    properties:
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: The selector for the ingress-gateway.
+                        type: object
+                    type: object
+                  config:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: A means to override the corresponding entries in the upstream
+                      configmaps
+                    type: object
+                  controller-custom-certs:
+                    description: Enabling the controller to trust registries with self-signed
+                      certificates
+                    properties:
+                      name:
+                        description: The name of the ConfigMap or Secret
+                        type: string
+                      type:
+                        description: One of ConfigMap or Secret
+                        enum:
+                        - ConfigMap
+                        - Secret
+                        - ""
+                        type: string
+                    type: object
+                  knative-ingress-gateway:
+                    description: A means to override the knative-ingress-gateway
+                    properties:
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: The selector for the ingress-gateway.
+                        type: object
+                    type: object
+                  registry:
+                    description: A means to override the corresponding deployment images
+                      in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                    properties:
+                      default:
+                        description: The default image reference template to use for all
+                          knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets to be used when pulling the knative
+                          images. The secret must be created in the same namespace as the
+                          knative-serving deployments, and not the namespace of this resource.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the secret.
+                              type: string
+                          type: object
+                        type: array
+                      override:
+                        additionalProperties:
+                          type: string
+                        description: A map of a container name or image name to the full
+                          image location of the individual knative image.
+                        type: object
+                    type: object
+                type: object
+              status:
+                description: Status defines the observed state of KnativeServing
+                properties:
+                  conditions:
+                    description: The latest available observations of a resource's current
+                      state.
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another. We use VolatileTime
+                            in place of metav1.Time to exclude this from creating equality.Semantic
+                            differences (all other things held constant).
+                          type: string
+                        message:
+                          description: A human readable message indicating details about
+                            the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        severity:
+                          description: Severity with which to treat failures of this type
+                            of condition. When this is not specified, it defaults to Error.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                      required:
+                      - type
+                      - status
+                      type: object
+                    type: array
+                  version:
+                    description: The version of the installed release
+                    type: string
+                type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
         name: knativeservings.serving.knative.dev
       spec:
         additionalPrinterColumns:
@@ -26,8 +184,6 @@ data:
           listKind: KnativeServingList
           plural: knativeservings
           singular: knativeserving
-          shortNames:
-          - ks
         scope: Namespaced
         subresources:
           status: {}
@@ -105,6 +261,595 @@ data:
           served: true
           storage: true
   clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"serving.knative.dev/v1alpha1","kind":"KnativeServing","metadata":{"name":"knative-serving"},"spec":{"config":{"autoscaler":{"container-concurrency-target-default":"100","container-concurrency-target-percentage":"1.0","enable-scale-to-zero":"true","max-scale-up-rate":"10","panic-threshold-percentage":"200.0","panic-window":"6s","panic-window-percentage":"10.0","scale-to-zero-grace-period":"30s","stable-window":"60s","tick-interval":"2s"},"defaults":{"revision-cpu-limit":"1000m","revision-cpu-request":"400m","revision-memory-limit":"200M","revision-memory-request":"100M","revision-timeout-seconds":"300"},"deployment":{"registriesSkippingTagResolving":"ko.local,dev.local"},"gc":{"stale-revision-create-delay":"24h","stale-revision-lastpinned-debounce":"5h","stale-revision-minimum-generations":"1","stale-revision-timeout":"15h"},"logging":{"loglevel.activator":"info","loglevel.autoscaler":"info","loglevel.controller":"info","loglevel.queueproxy":"info","loglevel.webhook":"info"},"observability":{"logging.enable-var-log-collection":"false","metrics.backend-destination":"prometheus"},"tracing":{"enable":"false","sample-rate":"0.1"}}}}]'
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.0.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat
+        name: serverless-operator.v1.0.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        description: |
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.7.1
+                      - name: IMAGE_activator
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.7.1
+                      - name: IMAGE_autoscaler
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.7.1
+                      - name: IMAGE_controller
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.7.1
+                      - name: IMAGE_networking-certmanager
+                        value: quay.io/openshift-knative/knative-serving-certmanager:v0.7.1
+                      - name: IMAGE_networking-istio
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.7.1
+                      - name: IMAGE_webhook
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.7.1
+                      image: quay.io/openshift-knative/knative-serving-operator:v0.7.1-TP1-04
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.7
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: knative@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        version: 1.0.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"serving.knative.dev/v1alpha1","kind":"KnativeServing","metadata":{"name":"knative-serving"},"spec":{"config":{"autoscaler":{"container-concurrency-target-default":"100","container-concurrency-target-percentage":"1.0","enable-scale-to-zero":"true","max-scale-up-rate":"10","panic-threshold-percentage":"200.0","panic-window":"6s","panic-window-percentage":"10.0","scale-to-zero-grace-period":"30s","stable-window":"60s","tick-interval":"2s"},"defaults":{"revision-cpu-limit":"1000m","revision-cpu-request":"400m","revision-memory-limit":"200M","revision-memory-request":"100M","revision-timeout-seconds":"300"},"deployment":{"registriesSkippingTagResolving":"ko.local,dev.local"},"gc":{"stale-revision-create-delay":"24h","stale-revision-lastpinned-debounce":"5h","stale-revision-minimum-generations":"1","stale-revision-timeout":"15h"},"logging":{"loglevel.activator":"info","loglevel.autoscaler":"info","loglevel.controller":"info","loglevel.queueproxy":"info","loglevel.webhook":"info"},"observability":{"logging.enable-var-log-collection":"false","metrics.backend-destination":"prometheus"},"tracing":{"enable":"false","sample-rate":"0.1"}}}}]'
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.1.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.1.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        description: |
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.8.1
+                      - name: IMAGE_activator
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.8.1
+                      - name: IMAGE_autoscaler
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.8.1
+                      - name: IMAGE_autoscaler-hpa
+                        value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.8.1
+                      - name: IMAGE_controller
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.8.1
+                      - name: IMAGE_networking-istio
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.8.1
+                      - name: IMAGE_webhook
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.8.1
+                      image: quay.io/openshift-knative/knative-serving-operator:v0.8.1-1.1.0-05
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.9
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        replaces: serverless-operator.v1.0.0
+        version: 1.1.0
     - apiVersion: operators.coreos.com/v1alpha1
       kind: ClusterServiceVersion
       metadata:
@@ -210,30 +955,39 @@ data:
         description: |-
           The Red Hat Serverless Operator provides a collection of API's to
           install various "serverless" services.
+
           This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
           # Knative Serving
+
           Knative Serving builds on Kubernetes to support deploying and
           serving of serverless applications and functions. Serving is easy
           to get started with and scales to support advanced scenarios. The
           Knative Serving project provides middleware primitives that
           enable:
+
           - Rapid deployment of serverless containers
           - Automatic scaling up and down to zero
           - Routing and network programming for Istio components
           - Point-in-time snapshots of deployed code and configurations
+
           ## Prerequisites
+
           The Serverless Operator's provided APIs such as Knative Serving
           have certain requirements with regards to the size of the underlying
           cluster and a working installation of Service Mesh. See the [installation
-          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#installing-openshift-serverless)
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
           of the Serverless documentation for more info.
+
           ## Further Information
+
           For documentation on using Knative Serving, see the
-          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index#knative-serving_serverless-architecture) of the
-          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index).
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
         displayName: OpenShift Serverless Operator
         icon:
-        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
           mediatype: image/svg+xml
         install:
           spec:
@@ -354,22 +1108,20 @@ data:
                       - name: OPERATOR_NAME
                         value: knative-serving-operator
                       - name: IMAGE_QUEUE
-                        value: ${IMAGE_QUEUE}
+                        value: quay.io/openshift-knative/knative-serving-queue:v0.9.0
                       - name: IMAGE_activator
-                        value: ${IMAGE_activator}
+                        value: quay.io/openshift-knative/knative-serving-activator:v0.9.0
                       - name: IMAGE_autoscaler
-                        value: ${IMAGE_autoscaler}
+                        value: quay.io/openshift-knative/knative-serving-autoscaler:v0.9.0
                       - name: IMAGE_autoscaler-hpa
-                        value: ${IMAGE_autoscaler_hpa}
+                        value: quay.io/openshift-knative/knative-serving-autoscaler-hpa:v0.9.0
                       - name: IMAGE_controller
-                        value: ${IMAGE_controller}
+                        value: quay.io/openshift-knative/knative-serving-controller:v0.9.0
                       - name: IMAGE_networking-istio
-                        value: ${IMAGE_networking_istio}
+                        value: quay.io/openshift-knative/knative-serving-istio:v0.9.0
                       - name: IMAGE_webhook
-                        value: ${IMAGE_webhook}
+                        value: quay.io/openshift-knative/knative-serving-webhook:v0.9.0
                       image: quay.io/openshift-knative/knative-serving-operator:v0.9.0-1.2.0-05
-                      args:
-                        - --filename=https://raw.githubusercontent.com/openshift/knative-serving/release-next/openshift/release/knative-serving-ci.yaml # remove this from individual release branches
                       imagePullPolicy: Always
                       name: knative-serving-operator
                       resources: {}
@@ -388,7 +1140,7 @@ data:
                     serviceAccountName: knative-openshift-ingress
                     containers:
                       - name: knative-openshift-ingress
-                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.1.2
+                        image: quay.io/openshift-knative/knative-openshift-ingress:v0.0.13
                         command:
                         - knative-openshift-ingress
                         imagePullPolicy: Always
@@ -471,7 +1223,7 @@ data:
         - serving
         links:
         - name: Documentation
-          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html-single/serverless/index
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
         - name: Source Repository
           url: https://github.com/openshift-knative/serverless-operator
         maintainers:
@@ -480,12 +1232,1746 @@ data:
         maturity: alpha
         provider:
           name: Red Hat, Inc.
+        replaces: serverless-operator.v1.1.0
         version: 1.2.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "serving.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.3.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.3.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        minKubeVersion: 1.14.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                strategy: {}
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - command:
+                      - knative-serving-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: IMAGE_QUEUE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-queue
+                      - name: IMAGE_activator
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-activator
+                      - name: IMAGE_autoscaler
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-autoscaler
+                      - name: IMAGE_autoscaler-hpa
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-autoscaler-hpa
+                      - name: IMAGE_controller
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-controller
+                      - name: IMAGE_networking-istio
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-istio
+                      - name: IMAGE_webhook
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.10.0:knative-serving-webhook
+                      image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.3.0:knative-serving-operator
+                      imagePullPolicy: Always
+                      name: knative-serving-operator
+                      resources: {}
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.3.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - serving.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        replaces: serverless-operator.v1.2.0
+        version: 1.3.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.4.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.4.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving (obsolete)
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        minKubeVersion: 1.14.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.1.13"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+                          - name: IMAGE_networking-istio
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+          - name: IMAGE_networking-istio
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+        replaces: serverless-operator.v1.3.0
+        version: 1.4.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.4.1
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.4.1
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving (obsolete)
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          required:
+          - description: A list of namespaces in Service Mesh
+            displayName: Istio Service Mesh Member Roll
+            kind: ServiceMeshMemberRoll
+            name: servicemeshmemberrolls.maistra.io
+            version: v1
+          - description: An Istio control plane installation
+            displayName: Istio Service Mesh Control Plane
+            kind: ServiceMeshControlPlane
+            name: servicemeshcontrolplanes.maistra.io
+            version: v1
+        minKubeVersion: 1.14.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              - apiGroups:
+                - maistra.io
+                resources:
+                - servicemeshmemberrolls
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.1.13"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+                          - name: IMAGE_networking-istio
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-controller
+          - name: IMAGE_networking-istio
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-istio
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.11.1:knative-serving-webhook
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.4.0:knative-openshift-ingress
+        replaces: serverless-operator.v1.4.0
+        version: 1.4.1
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.5.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.5.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving (obsolete)
+            kind: KnativeServing
+            name: knativeservings.serving.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+        minKubeVersion: 1.15.0
+        description: |-
+          The Red Hat Serverless Operator provides a collection of API's to
+          install various "serverless" services.
+
+          This is a **[Tech Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Knative Serving
+
+          Knative Serving builds on Kubernetes to support deploying and
+          serving of serverless applications and functions. Serving is easy
+          to get started with and scales to support advanced scenarios. The
+          Knative Serving project provides middleware primitives that
+          enable:
+
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming for Istio components
+          - Point-in-time snapshots of deployed code and configurations
+
+          ## Prerequisites
+
+          The Serverless Operator's provided APIs such as Knative Serving
+          have certain requirements with regards to the size of the underlying
+          cluster and a working installation of Service Mesh. See the [installation
+          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
+          of the Serverless documentation for more info.
+
+          ## Further Information
+
+          For documentation on using Knative Serving, see the
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
+          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      - name: KO_DATA_PATH
+                        value: /tmp/
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                      volumeMounts:
+                      - mountPath: /tmp/knative-serving
+                        name: release-manifest
+                    volumes:
+                    - name: release-manifest
+                      configMap:
+                        name: ko-data
+                        items:
+                        - key: knative-serving-ci.yaml
+                          path: knative-serving-ci.yaml
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.3.0"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: KOURIER_MANIFEST_PATH
+                            value: deploy/resources/kourier/kourier-latest.yaml
+                          - name: IMAGE_queue-proxy
+                            value: ${IMAGE_QUEUE}
+                          - name: IMAGE_activator
+                            value: ${IMAGE_activator}
+                          - name: IMAGE_autoscaler
+                            value: ${IMAGE_autoscaler}
+                          - name: IMAGE_autoscaler-hpa
+                            value: ${IMAGE_autoscaler}-hpa
+                          - name: IMAGE_controller
+                            value: ${IMAGE_controller}
+                          - name: IMAGE_webhook
+                            value: ${IMAGE_webhook}
+                          - name: IMAGE_3scale-kourier-gateway
+                            value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                          - name: IMAGE_3scale-kourier-control
+                            value: ${IMAGE_kourier}
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: ${IMAGE_QUEUE}
+          - name: IMAGE_activator
+            image: ${IMAGE_activator}
+          - name: IMAGE_autoscaler
+            image: ${IMAGE_autoscaler}
+          - name: IMAGE_autoscaler-hpa
+            image: ${IMAGE_autoscaler}-hpa
+          - name: IMAGE_controller
+            image: ${IMAGE_controller}
+          - name: IMAGE_webhook
+            image: ${IMAGE_webhook}
+          - name: IMAGE_3scale-kourier-control
+            image: ${IMAGE_kourier}
+          - name: IMAGE_3scale-kourier-gateway
+            image: docker.io/maistra/proxyv2-ubi8:1.0.8
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+        replaces: serverless-operator.v1.4.1
+        version: 1.5.0
   packages: |-
     - packageName: serverless-operator
       channels:
       - name: techpreview
-        currentCSV: serverless-operator.v1.2.0
+        currentCSV: serverless-operator.v1.5.0
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -33,6 +33,11 @@ function resolve_file() {
     return
   fi
 
+  # Skip istio resources, as we use kourier.
+  if grep -q 'networking.knative.dev/ingress-provider: istio' "$1"; then
+    return
+  fi
+
   echo "---" >> "$to"
   # 1. Rewrite image references
   # 2. Update config map entry


### PR DESCRIPTION
This patch contains following changes:
- to remove istio related resources
- to bump servleress-operator to v1.5.0

https://github.com/openshift/knative-serving/pull/408 proved CI pass.