### PR TITLE
[SRVKS-316] Use buildflag to workaround gcp behavior.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d)
 
 install:
 	for img in $(CORE_IMAGES); do \
-		go install $$img ; \
+		go install -tags="disable_gcp" $$img ; \
 	done
 .PHONY: install
 

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/$COMPONENT
 COPY . .
-ENV GOFLAGS="-mod=vendor"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp"
 RUN go build -o /tmp/$SUBCOMPONENT ./cmd/$GO_PACKAGE
 
 FROM ubi8-minimal:8-released


### PR DESCRIPTION
This is to make sure all future versions will use this build flag as well. Backport to 0.13 is here: #413.