### PR TITLE
Update GOFLAGS tags to use comma separated instead of space separated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d)
 
 install:
 	for img in $(CORE_IMAGES); do \
-		go install -tags="disable_gcp disable_aws disable_azure" $$img ; \
+		go install -tags="disable_gcp,disable_aws,disable_azure" $$img ; \
 	done
 .PHONY: install
 

--- a/openshift/productization/dist-git/Dockerfile.activator
+++ b/openshift/productization/dist-git/Dockerfile.activator
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/activator ./cmd/activator
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.autoscaler
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/autoscaler ./cmd/autoscaler
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
+++ b/openshift/productization/dist-git/Dockerfile.autoscaler-hpa
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/autoscaler-hpa ./cmd/autoscaler-hpa
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.controller
+++ b/openshift/productization/dist-git/Dockerfile.controller
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/controller ./cmd/controller
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.networking-certmanager
+++ b/openshift/productization/dist-git/Dockerfile.networking-certmanager
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/networking-certmanager ./cmd/networking/certmanager
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.networking-istio
+++ b/openshift/productization/dist-git/Dockerfile.networking-istio
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/networking-istio ./cmd/networking/istio
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.networking-nscert
+++ b/openshift/productization/dist-git/Dockerfile.networking-nscert
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/networking-nscert ./cmd/networking/nscert
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.queue
+++ b/openshift/productization/dist-git/Dockerfile.queue
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/queue ./cmd/queue
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/dist-git/Dockerfile.webhook
+++ b/openshift/productization/dist-git/Dockerfile.webhook
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/serving
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/webhook ./cmd/webhook
 
 FROM ubi8-minimal:8-released

--- a/openshift/productization/generate-dockerfiles/Dockerfile.in
+++ b/openshift/productization/generate-dockerfiles/Dockerfile.in
@@ -1,7 +1,7 @@
 FROM rhel8/go-toolset:1.13.4 AS builder
 WORKDIR /opt/app-root/src/go/src/knative.dev/$COMPONENT
 COPY . .
-ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
+ENV GOFLAGS="-mod=vendor -tags=disable_gcp,disable_aws,disable_azure"
 RUN go build -o /tmp/$SUBCOMPONENT ./cmd/$GO_PACKAGE
 
 FROM ubi8-minimal:8-released


### PR DESCRIPTION
Without this fix, there is a compile time error :

```
...
Step 4/9 : ENV GOFLAGS="-mod=vendor -tags='disable_gcp disable_aws disable_azure'"
 ---> Using cache
 ---> 58ce75944c2a
Step 5/9 : RUN go build -o /tmp/activator ./cmd/activator
 ---> Running in 79f97b2ae901
go: parsing $GOFLAGS: non-flag "disable_aws"
The command '/bin/sh -c go build -o /tmp/activator ./cmd/activator' returned a non-zero code: 1
```

Replacing spaces with commas in the `-tags` results in a successful build. However, I have currently not tested that the resulting binary works successfully in each of the cloud environments.