### PR TITLE
[WIP] Update catalogsource

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -143,7 +143,7 @@ spec:
   source: ${name}
   sourceNamespace: $OLM_NAMESPACE
   name: ${name}
-  channel: techpreview
+  channel: preview-4.3
 EOF
 }
 

--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -1,14 +1,14 @@
 diff --git a/openshift/olm/knative-serving.catalogsource.yaml b/openshift/olm/knative-serving.catalogsource.yaml
-index 5af9e00a2..a9da99ee1 100644
+index 65d5c549a..f5160f665 100644
 --- a/openshift/olm/knative-serving.catalogsource.yaml
 +++ b/openshift/olm/knative-serving.catalogsource.yaml
-@@ -2771,12 +2771,24 @@ data:
+@@ -3812,12 +3812,24 @@ data:
                              fieldPath: metadata.namespace
                        - name: METRICS_DOMAIN
                          value: knative.dev/serving-operator
 +                      - name: KO_DATA_PATH
 +                        value: /tmp/
-                       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
                        imagePullPolicy: IfNotPresent
                        name: knative-serving-operator
                        ports:
@@ -25,5 +25,5 @@ index 5af9e00a2..a9da99ee1 100644
 +                        - key: knative-serving-ci.yaml
 +                          path: knative-serving-ci.yaml
                      serviceAccountName: knative-serving-operator
-             - name: knative-serving-openshift
+             - name: knative-eventing-operator
                spec:

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -8,6 +8,84 @@ data:
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
       metadata:
+        name: knativeeventings.operator.knative.dev
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.version
+          name: Version
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        group: operator.knative.dev
+        names:
+          kind: KnativeEventing
+          listKind: KnativeEventingList
+          plural: knativeeventings
+          singular: knativeeventing
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec defines the desired state of KnativeEventing
+                properties:
+                  registry:
+                    description: A means to override the corresponding deployment images in the upstream.
+                      This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                    type: object
+                    properties:
+                      default:
+                        description: The default image reference template to use for all knative images.
+                          Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                        type: string
+                      override:
+                        description: A map of a container name or image name to the full image location of the individual knative image.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      imagePullSecrets:
+                        description: A list of secrets to be used when pulling the knative images. The secret must be created in the
+                          same namespace as the knative-eventing deployments, and not the namespace of this resource.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              description: The name of the secret.
+                              type: string
+                type: object
+              status:
+                properties:
+                  version:
+                    description: The version of the installed release
+                    type: string
+                type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
         name: knativeservings.operator.knative.dev
       spec:
         additionalPrinterColumns:
@@ -28,11 +106,13 @@ data:
           shortNames:
           - ks
           singular: knativeserving
+        preserveUnknownFields: false
         scope: Namespaced
         subresources:
           status: {}
         validation:
           openAPIV3Schema:
+            type: object
             description: Schema for the knativeservings API
             properties:
               apiVersion:
@@ -117,6 +197,14 @@ data:
                           image location of the individual knative image.
                         type: object
                     type: object
+                  high-availability:
+                    description: Allows specification of HA control plane
+                    type: object
+                    properties:
+                      replicas:
+                        description: The number of replicas that HA parts of the control plane will be scaled to
+                        type: integer
+                        minimum: 1
                 type: object
               status:
                 description: Status defines the observed state of KnativeServing
@@ -2639,22 +2727,20 @@ data:
 
           - Rapid deployment of serverless containers
           - Automatic scaling up and down to zero
-          - Routing and network programming for Istio components
+          - Routing and network programming
           - Point-in-time snapshots of deployed code and configurations
 
           ## Prerequisites
 
           The Serverless Operator's provided APIs such as Knative Serving
           have certain requirements with regards to the size of the underlying
-          cluster and a working installation of Service Mesh. See the [installation
-          section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#installing-openshift-serverless)
-          of the Serverless documentation for more info.
+          cluster. See [Getting started with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started)
+          for more info.
 
           ## Further Information
 
           For documentation on using Knative Serving, see the
-          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index#knative-serving_serverless-architecture) of the
-          [Serverless documentation site](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index).
+          [serving section](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#knative-serving).
 
         displayName: OpenShift Serverless Operator
         icon:
@@ -2803,7 +2889,7 @@ data:
                     serviceAccountName: knative-serving-operator
                     containers:
                       - name: knative-serving-openshift
-                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.5.0:knative-operator
                         command:
                         - knative-serving-openshift
                         imagePullPolicy: Always
@@ -2852,7 +2938,7 @@ data:
                     serviceAccountName: knative-openshift-ingress
                     containers:
                       - name: knative-openshift-ingress
-                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.5.0:knative-openshift-ingress
                         command:
                         - knative-openshift-ingress
                         imagePullPolicy: Always
@@ -2962,16 +3048,1062 @@ data:
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.5.0:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.5.0:knative-openshift-ingress
+        replaces: serverless-operator.v1.4.1
+        version: 1.5.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.6.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          operators.operatorframework.io/internal-objects: '["knativeservings.operator.knative.dev"]'
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.6.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+        minKubeVersion: 1.15.0
+        description: |-
+          The Red Hat OpenShift Serverless operator provides a collection of APIs that
+          enables containers, microservices and functions to run "serverless".
+          Serverless applications can scale up and down (to zero) on demand and be triggered by a
+          number of event sources. OpenShift Serverless integrates with a number of
+          platform services, such as Metering and Monitoring and it is based on the open
+          source project Knative.
+
+          This is a **[Technology Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Prerequisites
+          The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+          OpenShift Container Platform. For more information, see the documentation on [Getting started
+          with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started).
+
+          # Supported Features
+          - **Easy to get started:** Provides a simplified developer experience to deploy
+            and run cloud native applications on Kubernetes, providing powerful
+            abstractions.
+          - **Immutable Revisions:** Deploy new features performing canary, A/B or
+            blue-green testing with gradual traffic rollout following best practices.
+          - **Use any programming language or runtime of choice:** From Java, Python, Go
+            and JavaScript to Quarkus, SpringBoot or Node.js.
+          - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+            or idling behavior. Applications automatically scale to zero when not in use,
+            or scale up to meet demand, with built in reliability and fault tolerance.
+          - **Event Driven Applications:** You can build loosely coupled, distributed applications
+            that can be connected to a variety of either built in or third party event sources,
+            powered by operators.
+          - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+            that can run anywhere OpenShift Container Platform runs. You can leverage data
+            locality and SaaS as you need it.
+
+          # Components & APIs
+          This operator provides the following components:
+
+          ## Knative Serving
+          Knative Serving builds on Kubernetes to support deploying and serving of
+          applications and functions as serverless containers. Serving is easy to get
+          started with and scales to support advanced scenarios. Other features
+          includes:
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming
+          - Point-in-time snapshots of deployed code and configurations
+          ![](https://i.imgur.com/vqL48B8.png)
+
+          ## Knative Client - `kn`
+          The Knative client `kn` is your door to the Knative world. It allows you to
+          create Knative resources interactively from the command line or from within
+          Shell scripts.
+
+          `kn` offers you:
+          - Full support for managing all features of Knative Serving (services,
+            revisions, traffic splits)
+          - Growing support Knative eventing, closely following its development
+            (managing of sources & triggers)
+          - A plugin architecture similar to that of kubectl plugins
+          - A thin client-specific API in golang which helps in tasks like synchronously
+            waiting on Knative service write operations.
+          - An easy integration of Knative into Tekton Pipelines by using kn in a Tekton
+            Task.
+
+          # Further Information
+          For documentation on OpenShift Serverless, see:
+          - [Installation
+          Guide](https://docs.openshift.com/container-platform/4.3/serverless/installing-openshift-serverless.html)
+          - [Getting
+          started](https://docs.openshift.com/container-platform/4.3/serverless/serverless-getting-started.html)
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.3.0-0"
+                          - name: REQUIRED_NAMESPACE
+                            value: "knative-serving"
+                          - name: KOURIER_MANIFEST_PATH
+                            value: deploy/resources/kourier/kourier-latest.yaml
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+                          - name: IMAGE_3scale-kourier-gateway
+                            value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                          - name: IMAGE_3scale-kourier-control
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+          - name: IMAGE_3scale-kourier-control
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+          - name: IMAGE_3scale-kourier-gateway
+            image: docker.io/maistra/proxyv2-ubi8:1.0.8
+          - name: knative-serving-operator
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-openshift-ingress
+        replaces: serverless-operator.v1.5.0
+        version: 1.6.0
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                  "config": {
+                    "autoscaler": {
+                      "container-concurrency-target-default": "100",
+                      "container-concurrency-target-percentage": "1.0",
+                      "enable-scale-to-zero": "true",
+                      "max-scale-up-rate": "10",
+                      "panic-threshold-percentage": "200.0",
+                      "panic-window": "6s",
+                      "panic-window-percentage": "10.0",
+                      "scale-to-zero-grace-period": "30s",
+                      "stable-window": "60s",
+                      "tick-interval": "2s"
+                    },
+                    "defaults": {
+                      "revision-cpu-limit": "1000m",
+                      "revision-cpu-request": "400m",
+                      "revision-memory-limit": "200M",
+                      "revision-memory-request": "100M",
+                      "revision-timeout-seconds": "300"
+                    },
+                    "deployment": {
+                      "registriesSkippingTagResolving": "ko.local,dev.local"
+                    },
+                    "gc": {
+                      "stale-revision-create-delay": "24h",
+                      "stale-revision-lastpinned-debounce": "5h",
+                      "stale-revision-minimum-generations": "1",
+                      "stale-revision-timeout": "15h"
+                    },
+                    "logging": {
+                      "loglevel.activator": "info",
+                      "loglevel.autoscaler": "info",
+                      "loglevel.controller": "info",
+                      "loglevel.queueproxy": "info",
+                      "loglevel.webhook": "info"
+                    },
+                    "observability": {
+                      "logging.enable-var-log-collection": "false",
+                      "metrics.backend-destination": "prometheus"
+                    },
+                    "tracing": {
+                      "backend": "none",
+                      "sample-rate": "0.1"
+                    }
+                  }
+                }
+              },
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeEventing",
+                "metadata": {
+                  "name": "knative-eventing"
+                },
+                "spec": {
+                }
+              }
+            ]
+          capabilities: Seamless Upgrades
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          containerImage: quay.io/openshift-knative/serverless-operator:v1.7.0
+          createdAt: "2019-07-27T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          operators.operatorframework.io/internal-objects: '["knativeservings.operator.knative.dev","knativeeventings.operator.knative.dev"]'
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.7.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Eventing
+            displayName: Knative Eventing
+            kind: KnativeEventing
+            name: knativeeventings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Eventing installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        minKubeVersion: 1.15.0
+        description: |-
+          The Red Hat OpenShift Serverless operator provides a collection of APIs that
+          enables containers, microservices and functions to run "serverless".
+          Serverless applications can scale up and down (to zero) on demand and be triggered by a
+          number of event sources. OpenShift Serverless integrates with a number of
+          platform services, such as Metering and Monitoring and it is based on the open
+          source project Knative.
+
+          This is a **[Technology Preview release](https://access.redhat.com/support/offerings/techpreview)!**
+
+          # Prerequisites
+          The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+          OpenShift Container Platform. For more information, see the documentation on [Getting started
+          with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started).
+
+          # Supported Features
+          - **Easy to get started:** Provides a simplified developer experience to deploy
+            and run cloud native applications on Kubernetes, providing powerful
+            abstractions.
+          - **Immutable Revisions:** Deploy new features performing canary, A/B or
+            blue-green testing with gradual traffic rollout following best practices.
+          - **Use any programming language or runtime of choice:** From Java, Python, Go
+            and JavaScript to Quarkus, SpringBoot or Node.js.
+          - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+            or idling behavior. Applications automatically scale to zero when not in use,
+            or scale up to meet demand, with built in reliability and fault tolerance.
+          - **Event Driven Applications:** You can build loosely coupled, distributed applications
+            that can be connected to a variety of either built in or third party event sources,
+            powered by operators.
+          - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+            that can run anywhere OpenShift Container Platform runs. You can leverage data
+            locality and SaaS as you need it.
+
+          # Components & APIs
+          This operator provides the following components:
+
+          ## Knative Serving
+          Knative Serving builds on Kubernetes to support deploying and serving of
+          applications and functions as serverless containers. Serving is easy to get
+          started with and scales to support advanced scenarios. Other features
+          includes:
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming
+          - Point-in-time snapshots of deployed code and configurations
+          ![](https://i.imgur.com/vqL48B8.png)
+
+          ## Knative Eventing
+          Knative Eventing is a system that is designed to address a common need for cloud native
+          development and provides composable primitives to enable late-binding event sources and
+          event consumers.
+          Knative Eventing is designed to address a common need for cloud
+          native development:
+          - Services are loosely coupled during development and deployed independently
+          - A producer can generate events before a consumer is listening, and a consumer
+             can express an interest in an event or class of events that is not yet being
+             produced.
+          - Services can be connected to create new applications
+             * without modifying producer or consumer, and
+             * with the ability to select a specific subset of events from a particular
+               producer.
+
+          ## Knative Client - `kn`
+          The Knative client `kn` is your door to the Knative world. It allows you to
+          create Knative resources interactively from the command line or from within
+          Shell scripts.
+
+          `kn` offers you:
+          - Full support for managing all features of Knative Serving (services,
+            revisions, traffic splits)
+          - Growing support Knative eventing, closely following its development
+            (managing of sources & triggers)
+          - A plugin architecture similar to that of kubectl plugins
+          - A thin client-specific API in golang which helps in tasks like synchronously
+            waiting on Knative service write operations.
+          - An easy integration of Knative into Tekton Pipelines by using kn in a Tekton
+            Task.
+
+          # Further Information
+          For documentation on OpenShift Serverless, see:
+          - [Installation
+          Guide](https://docs.openshift.com/container-platform/4.3/serverless/installing-openshift-serverless.html)
+          - [Getting
+          started](https://docs.openshift.com/container-platform/4.3/serverless/serverless-getting-started.html)
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-eventing-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-eventing-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-eventing-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-eventing-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/eventing-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-eventing-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-serving-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-serving-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-serving-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        command:
+                        - knative-serving-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-serving-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.3.0-0"
+                          - name: REQUIRED_SERVING_NAMESPACE
+                            value: "knative-serving"
+                          - name: REQUIRED_EVENTING_NAMESPACE
+                            value: "knative-eventing"
+                          - name: KOURIER_MANIFEST_PATH
+                            value: deploy/resources/kourier/kourier-latest.yaml
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+                          - name: IMAGE_3scale-kourier-gateway
+                            value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                          - name: IMAGE_3scale-kourier-control
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+                          - name: IMAGE_eventing-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
+                          - name: IMAGE_eventing-webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-webhook
+                          - name: IMAGE_broker-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-broker
+                          - name: IMAGE_imc-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-controller
+                          - name: IMAGE_imc-dispatcher
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+                          - name: IMAGE_CRONJOB_RA_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-cronjob-receive-adapter
+                          - name: IMAGE_PING_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ping
+                          - name: IMAGE_APISERVER_RA_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-apiserver-receive-adapter
+                          - name: IMAGE_BROKER_INGRESS_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ingress
+                          - name: IMAGE_BROKER_FILTER_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-filter
+                          - name: IMAGE_DISPATCHER_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                - knative-eventing-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        - eventing
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: alpha
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+          - name: IMAGE_3scale-kourier-control
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+          - name: IMAGE_3scale-kourier-gateway
+            image: docker.io/maistra/proxyv2-ubi8:1.0.8
+          - name: knative-serving-operator
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+          - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
-        replaces: serverless-operator.v1.4.1
-        version: 1.5.0
+          - name: knative-eventing-operator
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+          - name: IMAGE_eventing-controller
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
+          - name: IMAGE_eventing-webhook
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-webhook
+          - name: IMAGE_broker-controller
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-broker
+          - name: IMAGE_imc-controller
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-controller
+          - name: IMAGE_imc-dispatcher
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+          - name: IMAGE_CRONJOB_RA_IMAGE
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-cronjob-receive-adapter
+          - name: IMAGE_PING_IMAGE
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ping
+          - name: IMAGE_APISERVER_RA_IMAGE
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-apiserver-receive-adapter
+          - name: IMAGE_BROKER_INGRESS_IMAGE
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ingress
+          - name: IMAGE_BROKER_FILTER_IMAGE
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-filter
+          - name: IMAGE_DISPATCHER_IMAGE
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+        replaces: serverless-operator.v1.6.0
+        version: 1.7.0
   packages: |-
     - packageName: serverless-operator
+      defaultChannel: preview-4.3
       channels:
       - name: techpreview
         currentCSV: serverless-operator.v1.5.0
+      - name: preview-4.3
+        currentCSV: serverless-operator.v1.7.0
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -3812,12 +3812,24 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
+                      - name: KO_DATA_PATH
+                        value: /tmp/
                       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
                       - containerPort: 9090
                         name: metrics
+                      volumeMounts:
+                      - mountPath: /tmp/knative-serving
+                        name: release-manifest
+                    volumes:
+                    - name: release-manifest
+                      configMap:
+                        name: ko-data
+                        items:
+                        - key: knative-serving-ci.yaml
+                          path: knative-serving-ci.yaml
                     serviceAccountName: knative-serving-operator
             - name: knative-eventing-operator
               spec:

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -2855,24 +2855,12 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
-                      - name: KO_DATA_PATH
-                        value: /tmp/
                       image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
                       - containerPort: 9090
                         name: metrics
-                      volumeMounts:
-                      - mountPath: /tmp/knative-serving
-                        name: release-manifest
-                    volumes:
-                    - name: release-manifest
-                      configMap:
-                        name: ko-data
-                        items:
-                        - key: knative-serving-ci.yaml
-                          path: knative-serving-ci.yaml
                     serviceAccountName: knative-serving-operator
             - name: knative-serving-openshift
               spec:
@@ -2909,21 +2897,21 @@ data:
                           - name: KOURIER_MANIFEST_PATH
                             value: deploy/resources/kourier/kourier-latest.yaml
                           - name: IMAGE_queue-proxy
-                            value: ${IMAGE_QUEUE}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
                           - name: IMAGE_activator
-                            value: ${IMAGE_activator}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
                           - name: IMAGE_autoscaler
-                            value: ${IMAGE_autoscaler}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler
                           - name: IMAGE_autoscaler-hpa
-                            value: ${IMAGE_autoscaler}-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
                           - name: IMAGE_controller
-                            value: ${IMAGE_controller}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
                           - name: IMAGE_webhook
-                            value: ${IMAGE_webhook}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: ${IMAGE_kourier}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
             - name: knative-openshift-ingress
               spec:
                 replicas: 1
@@ -3032,19 +3020,19 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: ${IMAGE_QUEUE}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-queue
           - name: IMAGE_activator
-            image: ${IMAGE_activator}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-activator
           - name: IMAGE_autoscaler
-            image: ${IMAGE_autoscaler}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler
           - name: IMAGE_autoscaler-hpa
-            image: ${IMAGE_autoscaler}-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-autoscaler-hpa
           - name: IMAGE_controller
-            image: ${IMAGE_controller}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-controller
           - name: IMAGE_webhook
-            image: ${IMAGE_webhook}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-webhook
           - name: IMAGE_3scale-kourier-control
-            image: ${IMAGE_kourier}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:kourier
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-operator
@@ -3370,21 +3358,21 @@ data:
                           - name: KOURIER_MANIFEST_PATH
                             value: deploy/resources/kourier/kourier-latest.yaml
                           - name: IMAGE_queue-proxy
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+                            value: ${IMAGE_QUEUE}
                           - name: IMAGE_activator
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+                            value: ${IMAGE_activator}
                           - name: IMAGE_autoscaler
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+                            value: ${IMAGE_autoscaler}
                           - name: IMAGE_autoscaler-hpa
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+                            value: ${IMAGE_autoscaler}-hpa
                           - name: IMAGE_controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+                            value: ${IMAGE_controller}
                           - name: IMAGE_webhook
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+                            value: ${IMAGE_webhook}
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+                            value: ${IMAGE_kourier}
             - name: knative-openshift-ingress
               spec:
                 replicas: 1
@@ -3493,19 +3481,19 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+            image: ${IMAGE_QUEUE}
           - name: IMAGE_activator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+            image: ${IMAGE_activator}
           - name: IMAGE_autoscaler
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+            image: ${IMAGE_autoscaler}
           - name: IMAGE_autoscaler-hpa
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+            image: ${IMAGE_autoscaler}-hpa
           - name: IMAGE_controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+            image: ${IMAGE_controller}
           - name: IMAGE_webhook
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+            image: ${IMAGE_webhook}
           - name: IMAGE_3scale-kourier-control
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+            image: ${IMAGE_kourier}
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-serving-operator
@@ -3902,21 +3890,21 @@ data:
                           - name: KOURIER_MANIFEST_PATH
                             value: deploy/resources/kourier/kourier-latest.yaml
                           - name: IMAGE_queue-proxy
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+                            value: ${IMAGE_QUEUE}
                           - name: IMAGE_activator
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+                            value: ${IMAGE_activator}
                           - name: IMAGE_autoscaler
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+                            value: ${IMAGE_autoscaler}
                           - name: IMAGE_autoscaler-hpa
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+                            value: ${IMAGE_autoscaler}-hpa
                           - name: IMAGE_controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+                            value: ${IMAGE_controller}
                           - name: IMAGE_webhook
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+                            value: ${IMAGE_webhook}
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+                            value: ${IMAGE_kourier}
                           - name: IMAGE_eventing-controller
                             value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
                           - name: IMAGE_eventing-webhook
@@ -4049,19 +4037,19 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
+            image: ${IMAGE_QUEUE}
           - name: IMAGE_activator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
+            image: ${IMAGE_activator}
           - name: IMAGE_autoscaler
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
+            image: ${IMAGE_autoscaler}
           - name: IMAGE_autoscaler-hpa
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
+            image: ${IMAGE_autoscaler}-hpa
           - name: IMAGE_controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
+            image: ${IMAGE_controller}
           - name: IMAGE_webhook
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
+            image: ${IMAGE_webhook}
           - name: IMAGE_3scale-kourier-control
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
+            image: ${IMAGE_kourier}
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-serving-operator


### PR DESCRIPTION
As per title, this patch updates catalog source.

Current CI is failing due to missing `KnativeEventing` CRD as:

https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_knative-serving/437/pull-ci-openshift-knative-serving-release-next-4.3-e2e-aws-ocp-43/240/artifacts/e2e-aws-ocp-43/pods/openshift-operators_knative-serving-openshift-fddcb5dd4-vmrnf_knative-serving-openshift.log