### PR TITLE
[SRVKS-227] Completely disable prometheus exporter endpoints.

### DIFF
--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -2803,7 +2803,7 @@ data:
                     serviceAccountName: knative-serving-operator
                     containers:
                       - name: knative-serving-openshift
-                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-operator
                         command:
                         - knative-serving-openshift
                         imagePullPolicy: Always
@@ -2852,7 +2852,7 @@ data:
                     serviceAccountName: knative-openshift-ingress
                     containers:
                       - name: knative-openshift-ingress
-                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-openshift-ingress
                         command:
                         - knative-openshift-ingress
                         imagePullPolicy: Always
@@ -2962,9 +2962,9 @@ data:
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-operator
-            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-operator
           - name: knative-openshift-ingress
-            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.6.0:knative-openshift-ingress
         replaces: serverless-operator.v1.4.1
         version: 1.5.0
   packages: |-

--- a/vendor/knative.dev/pkg/metrics/prometheus_exporter.go
+++ b/vendor/knative.dev/pkg/metrics/prometheus_exporter.go
@@ -36,10 +36,10 @@ func newPrometheusExporter(config *metricsConfig, logger *zap.SugaredLogger) (vi
 	}
 	logger.Infof("Created Opencensus Prometheus exporter with config: %v. Start the server for Prometheus exporter.", config)
 	// Start the server for Prometheus scraping
-	go func() {
-		srv := startNewPromSrv(e, config.prometheusPort)
-		srv.ListenAndServe()
-	}()
+	//go func() {
+	//	srv := startNewPromSrv(e, config.prometheusPort)
+	//	srv.ListenAndServe()
+	//}()
 	return e, nil
 }
 


### PR DESCRIPTION
We'll eventually reenable this once we properly implement monitoring. For the time being, this stops any potential data leaks via this path.