### PR TITLE
Update catalogsource to use knative-openshift instead of knative-serving-openshift

### DIFF
--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -9,7 +9,7 @@
 
 set -e
 
-VERSION="v0.12.1"
+VERSION="v0.13.1"
 OUTFILE="knative-serving.catalogsource.yaml"
 
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-queue|$\{IMAGE_QUEUE\}|g" $OUTFILE

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -3865,24 +3865,24 @@ data:
                       - containerPort: 9090
                         name: metrics
                     serviceAccountName: knative-serving-operator
-            - name: knative-serving-openshift
+            - name: knative-openshift
               spec:
                 replicas: 1
                 selector:
                   matchLabels:
-                    name: knative-serving-openshift
+                    name: knative-openshift
                 template:
                   metadata:
                     labels:
-                      name: knative-serving-openshift
+                      name: knative-openshift
                       app: openshift-admission-server
                   spec:
                     serviceAccountName: knative-serving-operator
                     containers:
-                      - name: knative-serving-openshift
+                      - name: knative-openshift
                         image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
                         command:
-                        - knative-serving-openshift
+                        - knative-openshift
                         imagePullPolicy: Always
                         env:
                           - name: WATCH_NAMESPACE
@@ -3892,7 +3892,7 @@ data:
                               fieldRef:
                                 fieldPath: metadata.name
                           - name: OPERATOR_NAME
-                            value: "knative-serving-openshift"
+                            value: "knative-openshift"
                           - name: MIN_OPENSHIFT_VERSION
                             value: "4.3.0-0"
                           - name: REQUIRED_SERVING_NAMESPACE
@@ -4098,11 +4098,15 @@ data:
         version: 1.7.0
   packages: |-
     - packageName: serverless-operator
-      defaultChannel: preview-4.3
+      defaultChannel: "4.3"
       channels:
-      - name: techpreview
+      - name: "techpreview"
         currentCSV: serverless-operator.v1.5.0
-      - name: preview-4.3
+      - name: "preview-4.3"
+        currentCSV: serverless-operator.v1.6.0
+      - name: "4.3"
+        currentCSV: serverless-operator.v1.7.0
+      - name: "4.4"
         currentCSV: serverless-operator.v1.7.0
 ---
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Since https://github.com/openshift-knative/serverless-operator/pull/234 changed the command, this patch updates catalogsource to use `knative-openshift` instead of `knative-serving-openshift`.

https://github.com/openshift/knative-serving/pull/441 proved that it solved https://github.com/openshift/knative-serving/pull/437's current failure and started e2e tests.

/cc @markusthoemmes 