### PR TITLE
[SRVKS-472, SRVKS-473, SRVKS-470] HA tests for autoscaler-hpa, controller, activator

### DIFF
--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -2771,7 +2771,7 @@ data:
                         value: knative.dev/serving-operator
                       - name: KO_DATA_PATH
                         value: /tmp/
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.12.1:knative-serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -233,6 +233,15 @@ func WithServiceAnnotations(annotations map[string]string) ServiceOption {
 	}
 }
 
+// WithConfigAnnotations assigns config annotations to a service
+func WithConfigAnnotations(annotations map[string]string) ServiceOption {
+	return func(service *v1.Service) {
+		service.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations = presources.UnionMaps(
+			service.Spec.ConfigurationSpec.Template.ObjectMeta.Annotations, annotations)
+
+	}
+}
+
 // WithServiceDeletionTimestamp will set the DeletionTimestamp on the Service.
 func WithServiceDeletionTimestamp(r *v1.Service) {
 	t := metav1.NewTime(time.Unix(1e9, 0))

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -87,11 +87,18 @@ if [[ -n "${ISTIO_VERSION}" ]]; then
 fi
 
 # Run HA tests separately as they're stopping core Knative Serving pods
-kubectl -n knative-serving patch configmap/config-leader-election --type=merge \
-  --patch='{"data":{"enabledComponents":"controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"}}'
-add_trap "kubectl get cm config-leader-election -n knative-serving -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m -parallel=1 ./test/ha || failed=1
-kubectl get cm config-leader-election -n knative-serving -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
+kubectl -n "${E2E_SYSTEM_NAMESPACE}" patch configmap/config-leader-election --type=merge \
+  --patch='{"data":{"enabledComponents":"controller,hpaautoscaler"}}'
+add_trap "kubectl get cm config-leader-election -n ${E2E_SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
+# Delete HPA to stabilize HA tests
+kubectl -n "${E2E_SYSTEM_NAMESPACE}" delete hpa activator
+# Scale up components for HA tests
+for deployment in controller autoscaler-hpa activator; do
+  kubectl -n "${E2E_SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
+done
+# Define short -spoofinterval to ensure frequent probing while stopping pods
+go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" -spoofinterval="10ms" || failed=1
+kubectl get cm config-leader-election -n "${E2E_SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -86,6 +86,13 @@ if [[ -n "${ISTIO_VERSION}" ]]; then
     "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
 
+# Run HA tests separately as they're stopping core Knative Serving pods
+kubectl -n knative-serving patch configmap/config-leader-election --type=merge \
+  --patch='{"data":{"enabledComponents":"controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"}}'
+add_trap "kubectl get cm config-leader-election -n knative-serving -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=10m -parallel=1 ./test/ha || failed=1
+kubectl get cm config-leader-election -n knative-serving -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
+
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state
 (( failed )) && fail_test

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -89,7 +89,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatal("Error creating spoofing client:", err)
 	}
 
-	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).List(metav1.ListOptions{
+	pods, err := clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).List(metav1.ListOptions{
 		LabelSelector: activatorLabel,
 	})
 	if err != nil {
@@ -102,7 +102,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Unable to get public endpoints for revision %s: %v", resourcesScaleToZero.Revision.Name, err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(activatorPod, &metav1.DeleteOptions{
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(activatorPod, &metav1.DeleteOptions{
 		GracePeriodSeconds: ptr.Int64(0),
 	})
 
@@ -121,7 +121,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Deployment %s failed to scale up: %v", activatorDeploymentName, err)
 	}
 
-	pods, err = clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).List(metav1.ListOptions{
+	pods, err = clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).List(metav1.ListOptions{
 		LabelSelector: activatorLabel,
 	})
 	if err != nil {
@@ -139,7 +139,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Unable to get public endpoints for revision %s: %v", resourcesScaleToZero.Revision.Name, err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(activatorPod, &metav1.DeleteOptions{
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(activatorPod, &metav1.DeleteOptions{
 		GracePeriodSeconds: ptr.Int64(0),
 	})
 

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -1,0 +1,163 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"log"
+	"sort"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+)
+
+const (
+	activatorDeploymentName = "activator"
+	activatorLabel          = "app=activator"
+	SLO                     = 0.99 // We permit 0.01 of requests to fail due to killing the Activator.
+)
+
+// The Activator does not have leader election enabled.
+// The test ensures that stopping one of the activator pods doesn't affect user applications.
+// One service is probed during activator restarts and another service is used for testing
+// that we can scale from zero after activator restart.
+func TestActivatorHA(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	if err := waitForDeploymentScale(clients, activatorDeploymentName, haReplicas); err != nil {
+		t.Fatalf("Deployment %s not scaled to %d: %v", activatorDeploymentName, haReplicas, err)
+	}
+
+	// Create first service that we will continually probe during activator restart.
+	names, resources := createPizzaPlanetService(t,
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.MinScaleAnnotationKey:  "1",  // Make sure we don't scale to zero during the test.
+			autoscaling.TargetBurstCapacityKey: "-1", // Make sure all requests go through the activator.
+		}),
+	)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	// Create second service that will be scaled to zero and after stopping the activator we'll
+	// ensure it can be scaled back from zero.
+	namesScaleToZero, resourcesScaleToZero := createPizzaPlanetService(t,
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(), // Make sure we scale to zero quickly.
+			autoscaling.TargetBurstCapacityKey: "-1",                           // Make sure all requests go through the activator.
+		}),
+	)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, namesScaleToZero) })
+	defer test.TearDown(clients, namesScaleToZero)
+
+	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resourcesScaleToZero.Revision), clients); err != nil {
+		t.Fatal("Failed to scale to zero:", err)
+	}
+
+	prober := test.RunRouteProber(log.Printf, clients, resources.Service.Status.URL.URL())
+	defer assertSLO(t, prober)
+
+	scaleToZeroURL := resourcesScaleToZero.Service.Status.URL.URL()
+	spoofingClient, err := pkgTest.NewSpoofingClient(
+		clients.KubeClient,
+		t.Logf,
+		scaleToZeroURL.Hostname(),
+		test.ServingFlags.ResolvableDomain)
+
+	if err != nil {
+		t.Fatal("Error creating spoofing client:", err)
+	}
+
+	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).List(metav1.ListOptions{
+		LabelSelector: activatorLabel,
+	})
+	if err != nil {
+		t.Fatal("Failed to get activator pods:", err)
+	}
+	activatorPod := pods.Items[0].Name
+
+	origEndpoints, err := getPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name)
+	if err != nil {
+		t.Fatalf("Unable to get public endpoints for revision %s: %v", resourcesScaleToZero.Revision.Name, err)
+	}
+
+	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(activatorPod, &metav1.DeleteOptions{
+		GracePeriodSeconds: ptr.Int64(0),
+	})
+
+	// Wait for the killed activator to disappear from the knative service's endpoints.
+	if err := waitForChangedPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name, origEndpoints); err != nil {
+		t.Fatal("Failed to wait for the service to update its endpoints:", err)
+	}
+
+	// Assert the service at the first possible moment after the killed activator disappears from its endpoints.
+	assertServiceWorksNow(t, clients, spoofingClient, namesScaleToZero, scaleToZeroURL, test.PizzaPlanetText1)
+
+	if err := waitForPodDeleted(t, clients, activatorPod); err != nil {
+		t.Fatalf("Did not observe %s to actually be deleted: %v", activatorPod, err)
+	}
+	if err := waitForDeploymentScale(clients, activatorDeploymentName, haReplicas); err != nil {
+		t.Fatalf("Deployment %s failed to scale up: %v", activatorDeploymentName, err)
+	}
+
+	pods, err = clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).List(metav1.ListOptions{
+		LabelSelector: activatorLabel,
+	})
+	if err != nil {
+		t.Fatal("Failed to get activator pods:", err)
+	}
+
+	// Sort the pods according to creation timestamp so that we can kill the oldest one. We want to
+	// gradually kill both activator pods that were started at the beginning.
+	sort.Slice(pods.Items, func(i, j int) bool { return pods.Items[i].CreationTimestamp.Before(&pods.Items[j].CreationTimestamp) })
+
+	activatorPod = pods.Items[0].Name // Stop the oldest activator pod remaining.
+
+	origEndpoints, err = getPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name)
+	if err != nil {
+		t.Fatalf("Unable to get public endpoints for revision %s: %v", resourcesScaleToZero.Revision.Name, err)
+	}
+
+	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(activatorPod, &metav1.DeleteOptions{
+		GracePeriodSeconds: ptr.Int64(0),
+	})
+
+	// Wait for the killed activator to disappear from the knative service's endpoints.
+	if err := waitForChangedPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name, origEndpoints); err != nil {
+		t.Fatal("Failed to wait for the service to update its endpoints:", err)
+	}
+
+	// Assert the service at the first possible moment after the killed activator disappears from its endpoints.
+	assertServiceWorksNow(t, clients, spoofingClient, namesScaleToZero, scaleToZeroURL, test.PizzaPlanetText1)
+}
+
+func assertSLO(t *testing.T, p test.Prober) {
+	t.Helper()
+	if err := p.Stop(); err != nil {
+		t.Error("Failed to stop prober:", err)
+	}
+	if err := test.CheckSLO(SLO, t.Name(), p); err != nil {
+		t.Error("CheckSLO failed:", err)
+	}
+}

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -1,0 +1,89 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+const (
+	autoscalerHPALease          = "hpaautoscaler"
+	autoscalerHPADeploymentName = "autoscaler-hpa"
+)
+
+func TestAutoscalerHPAHANewRevision(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	if err := scaleUpDeployment(clients, autoscalerHPADeploymentName); err != nil {
+		t.Fatalf("Failed to scale deployment: %v", err)
+	}
+	defer scaleDownDeployment(clients, autoscalerHPADeploymentName)
+	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, autoscalerHPADeploymentName) })
+
+	names, resources := createPizzaPlanetService(t, "pizzaplanet-service",
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.ClassAnnotationKey:  autoscaling.HPA,
+			autoscaling.MetricAnnotationKey: autoscaling.CPU,
+			autoscaling.TargetAnnotationKey: "70",
+		}))
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	leaderController, err := getLeader(t, clients, autoscalerHPALease)
+	if err != nil {
+		t.Fatalf("Failed to get leader: %v", err)
+	}
+
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+
+	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
+		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)
+	}
+
+	// Make sure a new leader has been elected
+	if _, err = getLeader(t, clients, autoscalerHPALease); err != nil {
+		t.Fatalf("Failed to find new leader: %v", err)
+	}
+
+	url := resources.Service.Status.URL.URL()
+	assertServiceWorks(t, clients, names, url, test.PizzaPlanetText1)
+
+	t.Log("Updating the Service after selecting new leader controller in order to generate a new revision")
+	names.Image = test.PizzaPlanet2
+	newImage := pkgTest.ImagePath(names.Image)
+	if _, err := v1test.PatchService(t, clients, resources.Service, rtesting.WithServiceImage(newImage)); err != nil {
+		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, newImage, err)
+	}
+
+	t.Log("Service should be able to generate a new revision after changing the leader controller")
+	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
+	if err != nil {
+		t.Fatalf("New image not reflected in Service: %v", err)
+	}
+
+	assertServiceWorks(t, clients, names, url, test.PizzaPlanetText2)
+}

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -44,6 +44,11 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	defer scaleDownDeployment(clients, autoscalerHPADeploymentName)
 	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, autoscalerHPADeploymentName) })
 
+	leaderController, err := getLeader(t, clients, autoscalerHPALease)
+	if err != nil {
+		t.Fatalf("Failed to get leader: %v", err)
+	}
+
 	names, resources := createPizzaPlanetService(t, "pizzaplanet-service",
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:  autoscaling.HPA,
@@ -53,12 +58,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	leaderController, err := getLeader(t, clients, autoscalerHPALease)
-	if err != nil {
-		t.Fatalf("Failed to get leader: %v", err)
-	}
-
-	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -56,7 +56,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -1,0 +1,68 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+)
+
+const (
+	controllerDeploymentName = "controller"
+)
+
+func TestControllerHA(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	if err := scaleUpDeployment(clients, controllerDeploymentName); err != nil {
+		t.Fatalf("Failed to scale deployment: %v", err)
+	}
+	defer scaleDownDeployment(clients, controllerDeploymentName)
+	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, controllerDeploymentName) })
+
+	service1Names, resources := createPizzaPlanetService(t, "pizzaplanet-service1")
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
+	defer test.TearDown(clients, service1Names)
+
+	leaderController, err := getLeader(t, clients, controllerDeploymentName)
+	if err != nil {
+		t.Fatalf("Failed to get leader: %v", err)
+	}
+
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+
+	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
+		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)
+	}
+
+	// Make sure a new leader has been elected
+	if _, err = getLeader(t, clients, controllerDeploymentName); err != nil {
+		t.Fatalf("Failed to find new leader: %v", err)
+	}
+
+	assertServiceWorks(t, clients, service1Names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
+
+	// Verify that after changing the leader we can still create a new kservice
+	service2Names, _ := createPizzaPlanetService(t, "pizzaplanet-service2")
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, service2Names) })
+	test.TearDown(clients, service2Names)
+}

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -39,16 +39,16 @@ func TestControllerHA(t *testing.T) {
 	defer scaleDownDeployment(clients, controllerDeploymentName)
 	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, controllerDeploymentName) })
 
-	service1Names, resources := createPizzaPlanetService(t, "pizzaplanet-service1")
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
-	defer test.TearDown(clients, service1Names)
-
 	leaderController, err := getLeader(t, clients, controllerDeploymentName)
 	if err != nil {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+	service1Names, resources := createPizzaPlanetService(t, "pizzaplanet-service1")
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
+	defer test.TearDown(clients, service1Names)
+
+	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -46,7 +46,7 @@ func TestControllerHA(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
 	defer test.TearDown(clients, service1Names)
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	pkgTest "knative.dev/pkg/test"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+const (
+	servingNamespace = "knative-serving"
+	haReplicas       = 2
+)
+
+func getLeader(t *testing.T, clients *test.Clients, lease string) (string, error) {
+	var leader string
+	err := wait.PollImmediate(test.PollInterval, time.Minute, func() (bool, error) {
+		lease, err := clients.KubeClient.Kube.CoordinationV1().Leases(servingNamespace).Get(lease, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error getting lease %s: %w", lease, err)
+		}
+		leader = strings.Split(*lease.Spec.HolderIdentity, "_")[0]
+		// the leader must be an existing pod
+		return podExists(clients, leader)
+	})
+	return leader, err
+}
+
+func waitForPodDeleted(t *testing.T, clients *test.Clients, podName string) error {
+	return wait.PollImmediate(test.PollInterval, time.Minute, func() (bool, error) {
+		exists, err := podExists(clients, podName)
+		return !exists, err
+	})
+}
+
+func podExists(clients *test.Clients, podName string) (bool, error) {
+	if _, err := clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Get(podName, metav1.GetOptions{}); err != nil {
+		if apierrs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func scaleUpDeployment(clients *test.Clients, name string) error {
+	return scaleDeployment(clients, name, haReplicas)
+}
+
+func scaleDownDeployment(clients *test.Clients, name string) error {
+	return scaleDeployment(clients, name, 1 /*target number of replicas*/)
+}
+
+func scaleDeployment(clients *test.Clients, name string, replicas int) error {
+	scaleRequest := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: int32(replicas)}}
+	scaleRequest.Name = name
+	scaleRequest.Namespace = servingNamespace
+	if _, err := clients.KubeClient.Kube.AppsV1().Deployments(servingNamespace).UpdateScale(name, scaleRequest); err != nil {
+		return fmt.Errorf("error scaling: %w", err)
+	}
+	return pkgTest.WaitForDeploymentState(
+		clients.KubeClient,
+		name,
+		func(d *appsv1.Deployment) (bool, error) {
+			return d.Status.ReadyReplicas == int32(replicas), nil
+		},
+		"DeploymentIsScaled",
+		servingNamespace,
+		time.Minute,
+	)
+}
+
+func createPizzaPlanetService(t *testing.T, serviceName string, fopt ...rtesting.ServiceOption) (test.ResourceNames, *v1test.ResourceObjects) {
+	t.Helper()
+	clients := e2e.Setup(t)
+	names := test.ResourceNames{
+		Service: serviceName,
+		Image:   test.PizzaPlanet1,
+	}
+	resources, err := v1test.CreateServiceReady(t, clients, &names, fopt...)
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v", err)
+	}
+
+	assertServiceWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
+	return names, resources
+}
+
+func assertServiceWorks(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
+	t.Helper()
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		url,
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
+		"WaitForEndpointToServeText",
+		test.ServingFlags.ResolvableDomain); err != nil {
+		t.Fatal(fmt.Sprintf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err))
+	}
+}

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -18,17 +18,21 @@ package ha
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/serving"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
@@ -61,6 +65,30 @@ func waitForPodDeleted(t *testing.T, clients *test.Clients, podName string) erro
 	})
 }
 
+func getPublicEndpoints(t *testing.T, clients *test.Clients, revision string) ([]string, error) {
+	endpoints, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+			serving.RevisionLabelKey, revision,
+			networking.ServiceTypeKey, networking.ServiceTypePublic,
+		),
+	})
+	if err != nil || len(endpoints.Items) != 1 {
+		return nil, fmt.Errorf("no endpoints or error: %w", err)
+	}
+	var hosts []string
+	for _, addr := range endpoints.Items[0].Subsets[0].Addresses {
+		hosts = append(hosts, addr.IP)
+	}
+	return hosts, nil
+}
+
+func waitForChangedPublicEndpoints(t *testing.T, clients *test.Clients, revision string, origEndpoints []string) error {
+	return wait.PollImmediate(100*time.Millisecond, time.Minute, func() (bool, error) {
+		newEndpoints, err := getPublicEndpoints(t, clients, revision)
+		return !cmp.Equal(origEndpoints, newEndpoints), err
+	})
+}
+
 func podExists(clients *test.Clients, podName string) (bool, error) {
 	if _, err := clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Get(podName, metav1.GetOptions{}); err != nil {
 		if apierrs.IsNotFound(err) {
@@ -71,26 +99,12 @@ func podExists(clients *test.Clients, podName string) (bool, error) {
 	return true, nil
 }
 
-func scaleUpDeployment(clients *test.Clients, name string) error {
-	return scaleDeployment(clients, name, haReplicas)
-}
-
-func scaleDownDeployment(clients *test.Clients, name string) error {
-	return scaleDeployment(clients, name, 1 /*target number of replicas*/)
-}
-
-func scaleDeployment(clients *test.Clients, name string, replicas int) error {
-	scaleRequest := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: int32(replicas)}}
-	scaleRequest.Name = name
-	scaleRequest.Namespace = servingNamespace
-	if _, err := clients.KubeClient.Kube.AppsV1().Deployments(servingNamespace).UpdateScale(name, scaleRequest); err != nil {
-		return fmt.Errorf("error scaling: %w", err)
-	}
+func waitForDeploymentScale(clients *test.Clients, name string, scale int) error {
 	return pkgTest.WaitForDeploymentState(
 		clients.KubeClient,
 		name,
 		func(d *appsv1.Deployment) (bool, error) {
-			return d.Status.ReadyReplicas == int32(replicas), nil
+			return d.Status.ReadyReplicas == int32(scale), nil
 		},
 		"DeploymentIsScaled",
 		servingNamespace,
@@ -98,11 +112,11 @@ func scaleDeployment(clients *test.Clients, name string, replicas int) error {
 	)
 }
 
-func createPizzaPlanetService(t *testing.T, serviceName string, fopt ...rtesting.ServiceOption) (test.ResourceNames, *v1test.ResourceObjects) {
+func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (test.ResourceNames, *v1test.ResourceObjects) {
 	t.Helper()
 	clients := e2e.Setup(t)
 	names := test.ResourceNames{
-		Service: serviceName,
+		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
 	resources, err := v1test.CreateServiceReady(t, clients, &names, fopt...)
@@ -110,11 +124,23 @@ func createPizzaPlanetService(t *testing.T, serviceName string, fopt ...rtesting
 		t.Fatalf("Failed to create Service: %v", err)
 	}
 
-	assertServiceWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
+	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 	return names, resources
 }
 
-func assertServiceWorks(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
+func assertServiceWorksNow(t *testing.T, clients *test.Clients, spoofingClient *spoof.SpoofingClient, names test.ResourceNames, url *url.URL, expectedText string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	resp, err := spoofingClient.Do(req)
+	if err != nil || !strings.Contains(string(resp.Body), expectedText) {
+		t.Fatalf("Failed to verify service works. Response body: %s, Error: %v", string(resp.Body), err)
+	}
+}
+
+func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
 	t.Helper()
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
@@ -123,6 +149,6 @@ func assertServiceWorks(t pkgTest.TLegacy, clients *test.Clients, names test.Res
 		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain); err != nil {
-		t.Fatal(fmt.Sprintf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err))
+		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 }


### PR DESCRIPTION
Replaces https://github.com/openshift/knative-serving/pull/435
One of the upstream flakes should be fixed in this PR by backporting the commit "HA tests - create services after electing the leader". One other issue is probably a problem in Revision controller as I wrote on the linked flake.