### PR TITLE
Update Kourier version to v0.3.12

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -95,7 +95,7 @@ function install_knative(){
   export IMAGE_webhook=${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}
   # Kourier is not built in this project.
   # export IMAGE_kourier=${IMAGE_FORMAT//\$\{component\}/kourier}
-  export IMAGE_kourier="quay.io/3scale/kourier:v0.3.11"
+  export IMAGE_kourier="quay.io/3scale/kourier:v0.3.12"
   envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
   timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -142,7 +142,7 @@ spec:
   source: ${name}
   sourceNamespace: $OLM_NAMESPACE
   name: ${name}
-  channel: 4.4
+  channel: "4.4"
 EOF
 }
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -95,7 +95,6 @@ function install_knative(){
   export IMAGE_webhook=${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}
   # Kourier is not built in this project.
   # export IMAGE_kourier=${IMAGE_FORMAT//\$\{component\}/kourier}
-  export IMAGE_kourier="quay.io/3scale/kourier:v0.3.12"
   envsubst < openshift/olm/knative-serving.catalogsource.yaml | oc apply -n $OLM_NAMESPACE -f -
   timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE
@@ -143,7 +142,7 @@ spec:
   source: ${name}
   sourceNamespace: $OLM_NAMESPACE
   name: ${name}
-  channel: preview-4.3
+  channel: 4.4
 EOF
 }
 

--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -1,14 +1,14 @@
 diff --git a/openshift/olm/knative-serving.catalogsource.yaml b/openshift/olm/knative-serving.catalogsource.yaml
-index 65d5c549a..f5160f665 100644
+index 05f7eb1d8..5b97819d5 100644
 --- a/openshift/olm/knative-serving.catalogsource.yaml
 +++ b/openshift/olm/knative-serving.catalogsource.yaml
-@@ -3812,12 +3812,24 @@ data:
+@@ -3811,12 +3811,24 @@ data:
                              fieldPath: metadata.namespace
                        - name: METRICS_DOMAIN
                          value: knative.dev/serving-operator
 +                      - name: KO_DATA_PATH
 +                        value: /tmp/
-                       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+                       image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
                        imagePullPolicy: IfNotPresent
                        name: knative-serving-operator
                        ports:

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -9,7 +9,7 @@
 
 set -e
 
-VERSION="v0.13.1"
+VERSION="v0.13.2"
 OUTFILE="knative-serving.catalogsource.yaml"
 
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-queue|$\{IMAGE_QUEUE\}|g" $OUTFILE
@@ -18,6 +18,6 @@ sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-se
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler-hpa|$\{IMAGE_autoscaler_hpa\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-controller|$\{IMAGE_controller\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-webhook|$\{IMAGE_webhook\}|g" $OUTFILE
-sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:kourier|$\{IMAGE_kourier\}|g" $OUTFILE
+#sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:kourier|$\{IMAGE_kourier\}|g" $OUTFILE
 
 git apply config_map.patch

--- a/openshift/olm/generate.sh
+++ b/openshift/olm/generate.sh
@@ -18,6 +18,7 @@ sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-se
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-autoscaler-hpa|$\{IMAGE_autoscaler_hpa\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-controller|$\{IMAGE_controller\}|g" $OUTFILE
 sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:knative-serving-webhook|$\{IMAGE_webhook\}|g" $OUTFILE
+# Kourier is not built in this project so don't replace the image name with IMAGE_kourier
 #sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-$VERSION:kourier|$\{IMAGE_kourier\}|g" $OUTFILE
 
 git apply config_map.patch

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -3358,21 +3358,21 @@ data:
                           - name: KOURIER_MANIFEST_PATH
                             value: deploy/resources/kourier/kourier-latest.yaml
                           - name: IMAGE_queue-proxy
-                            value: ${IMAGE_QUEUE}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
                           - name: IMAGE_activator
-                            value: ${IMAGE_activator}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
                           - name: IMAGE_autoscaler
-                            value: ${IMAGE_autoscaler}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
                           - name: IMAGE_autoscaler-hpa
-                            value: ${IMAGE_autoscaler}-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
                           - name: IMAGE_controller
-                            value: ${IMAGE_controller}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
                           - name: IMAGE_webhook
-                            value: ${IMAGE_webhook}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: ${IMAGE_kourier}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
             - name: knative-openshift-ingress
               spec:
                 replicas: 1
@@ -3481,19 +3481,19 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: ${IMAGE_QUEUE}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-queue
           - name: IMAGE_activator
-            image: ${IMAGE_activator}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-activator
           - name: IMAGE_autoscaler
-            image: ${IMAGE_autoscaler}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler
           - name: IMAGE_autoscaler-hpa
-            image: ${IMAGE_autoscaler}-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-autoscaler-hpa
           - name: IMAGE_controller
-            image: ${IMAGE_controller}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-controller
           - name: IMAGE_webhook
-            image: ${IMAGE_webhook}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-webhook
           - name: IMAGE_3scale-kourier-control
-            image: ${IMAGE_kourier}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:kourier
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-serving-operator
@@ -3583,7 +3583,6 @@ data:
             Provides a collection of API's based on Knative to support deploying and serving
             of serverless applications and functions.
           repository: https://github.com/openshift-knative/serverless-operator
-          operators.operatorframework.io/internal-objects: '["knativeservings.operator.knative.dev","knativeeventings.operator.knative.dev"]'
           support: Red Hat, Inc.
         name: serverless-operator.v1.7.0
         namespace: placeholder
@@ -3696,9 +3695,9 @@ data:
           # Further Information
           For documentation on OpenShift Serverless, see:
           - [Installation
-          Guide](https://docs.openshift.com/container-platform/4.3/serverless/installing-openshift-serverless.html)
+          Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/installing-openshift-serverless-1)
           - [Getting
-          started](https://docs.openshift.com/container-platform/4.3/serverless/serverless-getting-started.html)
+          started](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/serverless-getting-started)
         displayName: OpenShift Serverless Operator
         icon:
         - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
@@ -3814,7 +3813,7 @@ data:
                         value: knative.dev/serving-operator
                       - name: KO_DATA_PATH
                         value: /tmp/
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
@@ -3916,7 +3915,7 @@ data:
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: ${IMAGE_kourier}
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kourier
                           - name: IMAGE_eventing-controller
                             value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
                           - name: IMAGE_eventing-webhook
@@ -4038,7 +4037,7 @@ data:
         - eventing
         links:
         - name: Documentation
-          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html-single/serverless/index
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/index
         - name: Source Repository
           url: https://github.com/openshift-knative/serverless-operator
         maintainers:
@@ -4061,11 +4060,11 @@ data:
           - name: IMAGE_webhook
             image: ${IMAGE_webhook}
           - name: IMAGE_3scale-kourier-control
-            image: ${IMAGE_kourier}
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kourier
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-serving-operator
-            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.1:knative-serving-operator
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress


### PR DESCRIPTION
As per title this patch updates Kourier version to v0.3.12,
which should solve `404` error.