### PR TITLE
[BACKPORT] Propagate Ingress status once ObservedGenerated matches generation.

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -154,7 +154,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 		return err
 	}
 
-	if ingress.GetObjectMeta().GetGeneration() != ingress.Status.ObservedGeneration || !ingress.Status.IsReady() {
+	if ingress.GetObjectMeta().GetGeneration() != ingress.Status.ObservedGeneration {
 		r.Status.MarkIngressNotConfigured()
 	} else {
 		r.Status.PropagateIngressStatus(ingress.Status)

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -311,6 +311,14 @@ func WithHosts(index int, hosts ...string) IngressOption {
 	}
 }
 
+// WithLoadbalancerFailed marks the respective status as failed using
+// the given reason and message.
+func WithLoadbalancerFailed(reason, message string) IngressOption {
+	return func(ingress *netv1alpha1.Ingress) {
+		ingress.Status.MarkLoadBalancerFailed(reason, message)
+	}
+}
+
 // SKSOption is a callback type for decorate SKS objects.
 type SKSOption func(sks *netv1alpha1.ServerlessService)
 

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -203,6 +203,13 @@ func MarkIngressNotConfigured(r *v1.Route) {
 	r.Status.MarkIngressNotConfigured()
 }
 
+// WithPropagatedStatus propagates the given IngressStatus into the routes status.
+func WithPropagatedStatus(status netv1alpha1.IngressStatus) RouteOption {
+	return func(r *v1.Route) {
+		r.Status.PropagateIngressStatus(status)
+	}
+}
+
 // MarkMissingTrafficTarget calls the method of the same name on .Status
 func MarkMissingTrafficTarget(kind, revision string) RouteOption {
 	return func(r *v1.Route) {


### PR DESCRIPTION
Currently, status propagation is gated by both the ObservedGeneration check and a readiness check. In effect, as long as the Ingress is not ready, the route will always only show "IngressNotConfigured", which isn't super helpful to the user.

This lifts this check to allow the actual status from the Ingress to bubble up into the route (and thus into the Service potentially) to allow for finer grained diagnostics towards the user.

Upstream PR was here: https://github.com/knative/serving/pull/7606