### PR TITLE
[BACKPORT] Shorten object name to avoid DNS issue defined (RFC 1035)

### DIFF
--- a/vendor/knative.dev/pkg/test/helpers/name.go
+++ b/vendor/knative.dev/pkg/test/helpers/name.go
@@ -23,6 +23,7 @@ import (
 	"time"
 	"unicode"
 
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/test"
 )
 
@@ -34,7 +35,7 @@ const (
 )
 
 func init() {
-	// Properly seed the random number generator so AppendRandomString() is actually random.
+	// Properly seed the random number generator so RandomString() is actually random.
 	// Otherwise, rerunning tests will generate the same names for the test resources, causing conflicts with
 	// already existing resources.
 	seed := time.Now().UTC().UnixNano()
@@ -49,7 +50,7 @@ func ObjectPrefixForTest(t test.T) string {
 
 // ObjectNameForTest generates a random object name based on the test name.
 func ObjectNameForTest(t test.T) string {
-	return AppendRandomString(ObjectPrefixForTest(t))
+	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
 }
 
 // AppendRandomString will generate a random string that begins with prefix.
@@ -58,13 +59,17 @@ func ObjectNameForTest(t test.T) string {
 // This method will use "-" as the separator between the prefix and
 // the random suffix.
 func AppendRandomString(prefix string) string {
+	return strings.Join([]string{prefix, RandomString()}, string(sep))
+}
+
+// RandomString will generate a random string.
+func RandomString() string {
 	suffix := make([]byte, randSuffixLen)
 
 	for i := range suffix {
 		suffix[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
-
-	return strings.Join([]string{prefix, string(suffix)}, string(sep))
+	return string(suffix)
 }
 
 // MakeK8sNamePrefix converts each chunk of non-alphanumeric character into a single dash


### PR DESCRIPTION
In serving, when running e2e test after changing the domainTempalte to
`{{.Name}}-{{.Namespace}}.{{Domain}}`, some tests failed with
following error:

```
Retrying for DNS error: Get http://service-to-service-call-via-activator-a-disabled-qgoluwzd-serving-tests.apps.ci-op-y42hx5lj-23b3e.origin-ci-int-aws.dev.rhcloud.com: dial tcp: lookup service-to-service-call-via-activator-a-disabled-qgoluwzd-serving-tests.apps.ci-op-y42hx5lj-23b3e.origin-ci-int-aws.dev.rhcloud.com: no such host
```

This is because DNS
label(`service-to-service-call-via-activator-a-disabled-qgoluwzd-serving-tests`)
became longer than 63 characters and breaches RFC 1035.

To fix it, this patch adds `kmeta.ChildNam` to `ObjectNameForTest()`.

The upstream fix is here: https://github.com/knative/pkg/commit/f68639f04b397e9b24ee9d8591db43fa448d2a9e