### PR TITLE
[WIP] Add SYSTEM_NAMESPACE env before go test

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -159,6 +159,7 @@ function run_e2e_tests(){
   header "Running tests"
   failed=0
 
+  export SYSTEM_NAMESPACE="knative-serving"
   export GATEWAY_OVERRIDE=kourier
   export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
   export INGRESS_CLASS=kourier.ingress.networking.knative.dev

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -78,7 +78,7 @@ func autoscalerCM(clients *test.Clients) (*autoscalerconfig.Config, error) {
 		autoscalerconfig.ConfigName,
 		metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get configmap %s/%s: %w", system.Namespace(), autoscalerconfig.ConfigName, err)
+		return nil, err
 	}
 	return autoscalerconfig.NewConfigFromMap(autoscalerCM.Data)
 }
@@ -120,17 +120,16 @@ func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clien
 
 // waitForActivatorEndpoints waits for the Service endpoints to match that of activator.
 func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.Clients) error {
-	var err error
-	pollErr := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	return wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
 		// We need to fetch the activator endpoints at every check, since it can change.
 		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
 			system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get endpoint %s/%s: %w", system.Namespace(), networking.ActivatorServiceName, err)
+			return false, nil
 		}
 		sks, err := clients.NetworkingClient.ServerlessServices.Get(resources.Revision.Name, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get SKS %s: %w", resources.Revision.Name, err)
+			return false, nil
 		}
 
 		svcEps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(
@@ -163,8 +162,4 @@ func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.
 		}
 		return false, nil
 	})
-	if pollErr != nil {
-		return fmt.Errorf("failed to get endpoint: %v; %w", pollErr, err)
-	}
-	return nil
 }


### PR DESCRIPTION
As per title, currently config-map (`config-autoscaler`) not found error happens as

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_knative-serving/454/pull-ci-openshift-knative-serving-release-next-4.3-e2e-aws-ocp-43/263