### PR TITLE
Add SYSTEM_NAMESPACE env before go test

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -159,6 +159,7 @@ function run_e2e_tests(){
   header "Running tests"
   failed=0
 
+  export SYSTEM_NAMESPACE="knative-serving"
   export GATEWAY_OVERRIDE=kourier
   export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
   export INGRESS_CLASS=kourier.ingress.networking.knative.dev


### PR DESCRIPTION
`SYSTEM_NAMESPACE` is assigned to random name in `e2e-common.sh`.

https://github.com/openshift/knative-serving/blob/release-next/test/e2e-common.sh#L51

Due to this,  `autoscalerCM()` in e2e tests fails to get config-autoscaler configmap.

To fix it, this patch `SYSTEM_NAMESPACE=knative-serving` before
running e2e test.
