### PR TITLE
Remove certmanager from Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/certmanager ./cmd/networking/nscert
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/nscert
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
 
 install:

--- a/openshift/ci-operator/knative-images/certmanager/Dockerfile
+++ b/openshift/ci-operator/knative-images/certmanager/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
-USER 65532
-
-ADD certmanager /ko-app/certmanager
-ENTRYPOINT ["/ko-app/certmanager"]


### PR DESCRIPTION
The certmanager was removed from upstream https://github.com/knative/serving/commit/392aa1233e49ff8953ac331b358bd02d737856d3

/cc @markusthoemmes 