### PR TITLE
Remove content_sets.yml and container.yaml

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -17,10 +17,10 @@ git checkout -b "$target" "$release"
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make generate-p12n-dockerfiles
 make RELEASE=$release generate-release
 make RELEASE=ci generate-release
-git add openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -12,10 +12,10 @@ git checkout upstream/master -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make RELEASE=ci generate-release
-git add openshift OWNERS_ALIASES OWNERS Makefile content_sets.yml container.yaml
+git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m ":open_file_folder: Update openshift specific files."
 
 # Apply patches .


### PR DESCRIPTION
When I removed the productization files in https://github.com/openshift/knative-serving/pull/482, I did not remove reference to the `content_sets.yml` and `container.yaml` files from the `openshift/release/create-release-branch.sh` and `openshift/release/update-to-head.sh` files. Those changes are made in this PR.