### PR TITLE
[WIP] Add object length limit patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+#This makefile is used by ci-operator
+
+CGO_ENABLED=0
+GOOS=linux
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/nscert
+TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
+
+install:
+	for img in $(CORE_IMAGES); do \
+		go install -tags="disable_gcp,disable_aws,disable_azure" $$img ; \
+	done
+.PHONY: install
+
+test-install:
+	for img in $(TEST_IMAGES); do \
+		go install $$img ; \
+	done
+.PHONY: test-install
+
+test-e2e:
+	./openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Generate Dockerfiles for core and test images used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+.PHONY: generate-dockerfiles
+
+# Generates a ci-operator configuration for a specific branch.
+generate-ci-config:
+	./openshift/ci-operator/generate-ci-config.sh $(BRANCH) > ci-operator-config.yaml
+.PHONY: generate-ci-config
+
+# Generate an aggregated knative yaml file with replaced image references
+generate-release:
+	./openshift/release/generate-release.sh $(RELEASE)
+.PHONY: generate-release

--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-wg-leads
+- serving-approvers
+
+reviewers:
+- serving-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,88 +1,134 @@
 aliases:
+  serving-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
+  serving-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
+
   serving-api-approvers:
-  - dprotaso
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
+  - evanchooly
+  - arilivigni
   serving-api-reviewers:
-  - dprotaso
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
-
-  toc:
-  - evankanderson
-  - grantr
-  - markusthoemmes
-  - mattmoor
-  - tcnghia
-
-  wg-leads:
-  - dprotaso        # API
-  - markusthoemmes  # Scaling
-  - mattmoor        # API
-  - mdemirhan       # Network
-  - tcnghia         # Network
-  - vagababov       # Scaling
-
-  # TOC + WG leads
-  serving-wg-leads:
-  - dprotaso        # API
-  - evankanderson   # TOC
-  - grantr          # TOC
-  - markusthoemmes  # Scaling/TOC
-  - mattmoor        # API/TOC
-  - mdemirhan       # Network
-  - tcnghia         # Network/TOC
-  - vagababov       # Scaling
+  - evanchooly
+  - arilivigni
 
   autoscaling-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - vagababov
+  - evanchooly
+  - arilivigni
   autoscaling-reviewers:
-  - julz
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - taragu
-  - vagababov
-  - yanweiguo
+  - evanchooly
+  - arilivigni
 
   monitoring-approvers:
-  - mdemirhan
-  - yanweiguo
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
   monitoring-reviewers:
-  - mdemirhan
-  - yanweiguo
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
 
   productivity-approvers:
-  - chaodaiG
-  - chizhg
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
   productivity-reviewers:
-  - chaodaiG
-  - coryrc
-  - chizhg
-  - steuhs
-  - yt3liu
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
 
   networking-approvers:
-  - JRBANCEL
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - nak3
-  - tcnghia
-  - vagababov
-  - ZhiminXiang
+  - evanchooly
+  - arilivigni
   networking-reviewers:
-  - andrew-su
-  - JRBANCEL
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
   - markusthoemmes
-  - mdemirhan
-  - nak3
-  - shashwathi
-  - tcnghia
-  - vagababov
-  - yanweiguo
-  - ZhiminXiang
+  - evanchooly
+  - arilivigni
+
+  build-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
+  build-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - evanchooly
+  - arilivigni
+

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD ${bin} /ko-app/${bin}
+ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,11 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM openshift/origin-release:golang-1.14
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+branch=${1-'knative-v0.3'}
+
+cat <<EOF
+tag_specification:
+  name: '4.1'
+  namespace: ocp
+promotion:
+  cluster: https://api.ci.openshift.org
+  namespace: openshift
+  name: $branch
+base_images:
+  base:
+    name: '4.1'
+    namespace: ocp
+    tag: base
+build_root:
+  project_image:
+    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
+canonical_go_repository: knative.dev/serving
+binary_build_commands: make install
+test_binary_build_commands: make test-install
+tests:
+- as: e2e-aws
+  commands: "make test-e2e"
+  openshift_installer_src:
+    cluster_profile: aws
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+images:
+EOF
+
+core_images=$(find ./openshift/ci-operator/knative-images -mindepth 1 -maxdepth 1 -type d)
+for img in $core_images; do
+  image_base=$(basename $img)
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-serving-$image_base
+EOF
+done
+
+test_images=$(find ./openshift/ci-operator/knative-test-images -mindepth 1 -maxdepth 1 -type d)
+for img in $test_images; do
+  image_base=$(basename $img)
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-test-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    test-bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-serving-test-$image_base
+EOF
+done

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD activator /ko-app/activator
+ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD autoscaler-hpa /ko-app/autoscaler-hpa
+ENTRYPOINT ["/ko-app/autoscaler-hpa"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD autoscaler /ko-app/autoscaler
+ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD controller /ko-app/controller
+ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/nscert/Dockerfile
+++ b/openshift/ci-operator/knative-images/nscert/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD nscert /ko-app/nscert
+ENTRYPOINT ["/ko-app/nscert"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD queue /ko-app/queue
+ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD webhook /ko-app/webhook
+ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD autoscale /ko-app/autoscale
+ENTRYPOINT ["/ko-app/autoscale"]

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD failing /ko-app/failing
+ENTRYPOINT ["/ko-app/failing"]

--- a/openshift/ci-operator/knative-test-images/flaky/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/flaky/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD flaky /ko-app/flaky
+ENTRYPOINT ["/ko-app/flaky"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD grpc-ping /ko-app/grpc-ping
+ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD hellovolume /ko-app/hellovolume
+ENTRYPOINT ["/ko-app/hellovolume"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD helloworld /ko-app/helloworld
+ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD httpproxy /ko-app/httpproxy
+ENTRYPOINT ["/ko-app/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/observed-concurrency/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD observed-concurrency /ko-app/observed-concurrency
+ENTRYPOINT ["/ko-app/observed-concurrency"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD pizzaplanetv1 /ko-app/pizzaplanetv1
+ENTRYPOINT ["/ko-app/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD pizzaplanetv2 /ko-app/pizzaplanetv2
+ENTRYPOINT ["/ko-app/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD runtime /ko-app/runtime
+ENTRYPOINT ["/ko-app/runtime"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD singlethreaded /ko-app/singlethreaded
+ENTRYPOINT ["/ko-app/singlethreaded"]

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD timeout /ko-app/timeout
+ENTRYPOINT ["/ko-app/timeout"]

--- a/openshift/ci-operator/knative-test-images/varlog/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/varlog/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD varlog /ko-app/varlog
+ENTRYPOINT ["/ko-app/varlog"]

--- a/openshift/ci-operator/knative-test-images/wsserver-hostname/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver-hostname/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD wsserver-hostname /ko-app/wsserver-hostname
+ENTRYPOINT ["/ko-app/wsserver-hostname"]

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD wsserver /ko-app/wsserver
+ENTRYPOINT ["/ko-app/wsserver"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
+source "$(dirname "$0")/release/resolve.sh"
+
+set -x
+
+readonly SERVING_NAMESPACE=knative-serving
+readonly SERVING_INGRESS_NAMESPACE=knative-serving-ingress
+
+# A golang template to point the tests to the right image coordinates.
+# {{.Name}} is the name of the image, for example 'autoscale'.
+readonly TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-serving-test-{{.Name}}}"
+
+# The OLM global namespace was moved to openshift-marketplace since v4.2
+# ref: https://jira.coreos.com/browse/OLM-1190
+readonly OLM_NAMESPACE="openshift-marketplace"
+
+env
+
+function scale_up_workers(){
+  local cluster_api_ns="openshift-machine-api"
+
+  oc get machineset -n ${cluster_api_ns} --show-labels
+
+  # Get the name of the first machineset that has at least 1 replica
+  local machineset
+  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
+  oc patch machineset -n ${cluster_api_ns} "${machineset}" -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} "${machineset}" 6
+}
+
+# Waits until the machineset in the given namespaces scales up to the
+# desired number of replicas
+# Parameters: $1 - namespace
+#             $2 - machineset name
+#             $3 - desired number of replicas
+function wait_until_machineset_scales_up() {
+  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local available
+    available=$(oc get machineset -n "$1" "$2" -o jsonpath="{.status.availableReplicas}")
+    if [[ ${available} -eq $3 ]]; then
+      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo - "Error: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  return 1
+}
+
+# Waits until the given hostname resolves via DNS
+# Parameters: $1 - hostname
+function wait_until_hostname_resolves() {
+  echo -n "Waiting until hostname $1 resolves via DNS"
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local output
+    output=$(host -t a "$1" | grep 'has address')
+    if [[ -n "${output}" ]]; then
+      echo -e "\n${output}"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\nERROR: timeout waiting for hostname $1 to resolve via DNS"
+  return 1
+}
+
+# Loops until duration (car) is exceeded or command (cdr) returns non-zero
+function timeout() {
+  SECONDS=0; TIMEOUT=$1; shift
+  while eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && return 1
+  done
+  return 0
+}
+
+function install_knative(){
+  header "Installing Knative"
+
+  oc new-project $SERVING_NAMESPACE
+
+  CATALOG_SOURCE="openshift/olm/knative-serving.catalogsource.yaml"
+
+  # Install CatalogSource in OLM namespace
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-queue|${IMAGE_FORMAT//\$\{component\}/knative-serving-queue}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-activator|${IMAGE_FORMAT//\$\{component\}/knative-serving-activator}|g"           ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-autoscaler|${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler}|g"         ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-autoscaler-hpa|${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler-hpa}|g" ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-controller|${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}|g"         ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-webhook|${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}|g"               ${CATALOG_SOURCE}
+
+  # release-next branch keeps updating the latest manifest in knative-serving-ci.yaml for serving resources.
+  # see: https://github.com/openshift/knative-serving/blob/release-next/openshift/release/knative-serving-ci.yaml
+  # So mount the manifest and use it by KO_DATA_PATH env value.
+  patch -u ${CATALOG_SOURCE} < openshift/olm/config_map.patch
+
+  oc apply -n $OLM_NAMESPACE -f ${CATALOG_SOURCE}
+  timeout 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c serverless) -eq 0 ]]' || return 1
+  wait_until_pods_running $OLM_NAMESPACE
+
+  # Deploy Serverless Operator
+  deploy_serverless_operator
+
+  # Wait for the CRD to appear
+  timeout 900 '[[ $(oc get crd | grep -c knativeservings) -eq 0 ]]' || return 1
+
+  # Install Knative Serving
+  cat <<-EOF | oc apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: ${SERVING_NAMESPACE}
+EOF
+
+  # Wait for 4 pods to appear first
+  timeout 900 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
+  wait_until_pods_running $SERVING_NAMESPACE || return 1
+
+  wait_until_service_has_external_ip $SERVING_INGRESS_NAMESPACE kourier || fail_test "Ingress has no external IP"
+  wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+
+  header "Knative Installed successfully"
+}
+
+function deploy_serverless_operator(){
+  local name="serverless-operator"
+  local operator_ns
+  operator_ns=$(kubectl get og --all-namespaces | grep global-operators | awk '{print $1}')
+
+  # Create configmap to use the latest manifest.
+  oc create configmap ko-data -n $operator_ns --from-file="openshift/release/knative-serving-ci.yaml"
+
+  cat <<-EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ${name}-subscription
+  namespace: ${operator_ns}
+spec:
+  source: ${name}
+  sourceNamespace: $OLM_NAMESPACE
+  name: ${name}
+  channel: "preview-4.6"
+EOF
+}
+
+function run_e2e_tests(){
+  echo ">> Creating test resources for OpenShift (test/config/)"
+  oc apply -f test/config
+
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
+  # adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
+  oc adm policy add-scc-to-user anyuid -z default -n serving-tests
+
+  header "Running tests"
+  failed=0
+
+  export SYSTEM_NAMESPACE="knative-serving"
+  export GATEWAY_OVERRIDE=kourier
+  export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
+  export INGRESS_CLASS=kourier.ingress.networking.knative.dev
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -short -parallel=3 \
+    ./test/e2e \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --resolvabledomain || failed=1
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
+    ./test/conformance/runtime/... \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --resolvabledomain "$(ingress_class)" || failed=1
+
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
+    ./test/conformance/api/... \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --resolvabledomain "$(ingress_class)" || failed=1
+
+  return $failed
+}
+
+scale_up_workers || exit 1
+
+failed=0
+(( !failed )) && install_knative || failed=1
+(( !failed )) && run_e2e_tests || failed=1
+(( failed )) && dump_cluster_state
+(( failed )) && exit 1
+
+success

--- a/openshift/olm/README.md
+++ b/openshift/olm/README.md
@@ -1,0 +1,49 @@
+
+This is the `CatalogSource` for the [knative-serving-operator](https://github.com/openshift-knative/knative-serving-operator).
+
+WARNING: The `knative-serving` operator refers to some Istio CRD's, so
+either install istio or...
+
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.5.1/istio-crds.yaml
+
+To install this `CatalogSource`:
+
+    OLM=$(kubectl get pods --all-namespaces | grep olm-operator | head -1 | awk '{print $1}')
+    kubectl apply -n $OLM -f https://raw.githubusercontent.com/openshift/knative-serving/release-v0.6.0/openshift/olm/knative-serving.catalogsource.yaml
+
+To install Knative Serving, either use the console, or apply the
+following yaml:
+
+```
+cat <<-EOF | kubectl apply -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: knative-serving-operator-sub
+  generateName: knative-serving-operator-
+  namespace: knative-serving
+spec:
+  source: knative-serving-operator
+  sourceNamespace: $OLM
+  name: knative-serving-operator
+  channel: alpha
+---
+apiVersion: serving.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+EOF
+```

--- a/openshift/olm/catalog.sh
+++ b/openshift/olm/catalog.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+OUTFILE="knative-serving.catalogsource.yaml"
+
+TMPDIR=$(mktemp -d)
+git clone --depth 1 https://github.com/openshift-knative/serverless-operator.git ${TMPDIR}
+VERSION=$(ls ${TMPDIR}/olm-catalog/serverless-operator/ |sort -n |tail -1)
+OLM_DIR=${TMPDIR}/olm-catalog/serverless-operator/${VERSION}
+
+indent() {
+  INDENT="      "
+  ENDASH="    - "
+  sed "s/^/$INDENT/" | sed "s/^${INDENT}\($1\)/${ENDASH}\1/"
+}
+
+export IMAGE_KNATIVE_OPERATOR="registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator"
+export IMAGE_KNATIVE_OPENSHIFT_INGRESS="registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress"
+
+CRD=$(cat $(ls $OLM_DIR/*_crd.yaml) | grep -v -- "---" | indent apiVersion)
+CSV=$(cat $(find $OLM_DIR -name '*version.yaml' | grep "${VERSION}" | sort -n) | envsubst '$IMAGE_KNATIVE_OPERATOR $IMAGE_KNATIVE_OPENSHIFT_INGRESS' | indent apiVersion)
+PKG=$(cat minimum.package.yaml | indent packageName)
+
+cat <<EOF | sed '/replaces:/d' | sed 's/^  *$//' > ${OUTFILE}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: serverless-operator
+
+data:
+  customResourceDefinitions: |-
+$CRD
+  clusterServiceVersions: |-
+$CSV
+  packages: |-
+$PKG
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: serverless-operator
+spec:
+  configMap: serverless-operator
+  displayName: "Serverless Operator"
+  publisher: Red Hat
+  sourceType: internal
+EOF

--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -1,0 +1,28 @@
+--- knative-serving.catalogsource.yaml.org	2020-04-24 18:07:55.175291572 +0900
++++ knative-serving.catalogsource.yaml	2020-04-24 18:08:16.631512089 +0900
+@@ -506,6 +506,8 @@
+                         valueFrom:
+                           fieldRef:
+                             fieldPath: metadata.name
++                      - name: KO_DATA_PATH
++                        value: /tmp/
+                       - name: OPERATOR_NAME
+                         value: knative-serving-operator
+                       - name: SYSTEM_NAMESPACE
+@@ -520,6 +522,16 @@
+                       ports:
+                       - containerPort: 9090
+                         name: metrics
++                      volumeMounts:
++                      - mountPath: /tmp/knative-serving
++                        name: release-manifest
++                    volumes:
++                    - name: release-manifest
++                      configMap:
++                        name: ko-data
++                        items:
++                        - key: knative-serving-ci.yaml
++                          path: knative-serving-ci.yaml
+                     serviceAccountName: knative-serving-operator
+             - name: knative-eventing-operator
+               spec:

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -514,7 +514,7 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
@@ -548,7 +548,7 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/eventing-operator
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-eventing-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-eventing-operator
                       ports:
@@ -594,21 +594,21 @@ data:
                           - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
                             value: deploy/resources/console_cli_download_kn_resources.yaml
                           - name: IMAGE_queue-proxy
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-queue
                           - name: IMAGE_activator
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-activator
                           - name: IMAGE_autoscaler
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler
                           - name: IMAGE_autoscaler-hpa
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler-hpa
                           - name: IMAGE_controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-controller
                           - name: IMAGE_webhook
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-webhook
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: quay.io/3scale/kourier:fix_duplication
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:kourier
                           - name: IMAGE_eventing-controller
                             value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
                           - name: IMAGE_eventing-webhook
@@ -743,29 +743,29 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-queue
           - name: IMAGE_activator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-activator
           - name: IMAGE_autoscaler
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler
           - name: IMAGE_autoscaler-hpa
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler-hpa
           - name: IMAGE_controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-controller
           - name: IMAGE_webhook
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-webhook
           - name: IMAGE_3scale-kourier-control
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kourier
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:kourier
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-serving-operator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-operator
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
           - name: knative-eventing-operator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-eventing-operator
           - name: IMAGE_eventing-controller
             image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
           - name: IMAGE_eventing-webhook

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -1,0 +1,809 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: serverless-operator
+
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: knativeeventings.operator.knative.dev
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.version
+          name: Version
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        group: operator.knative.dev
+        names:
+          kind: KnativeEventing
+          listKind: KnativeEventingList
+          plural: knativeeventings
+          singular: knativeeventing
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec defines the desired state of KnativeEventing
+                properties:
+                  registry:
+                    description: A means to override the corresponding deployment images in the upstream.
+                      This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                    type: object
+                    properties:
+                      default:
+                        description: The default image reference template to use for all knative images.
+                          Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                        type: string
+                      override:
+                        description: A map of a container name or image name to the full image location of the individual knative image.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      imagePullSecrets:
+                        description: A list of secrets to be used when pulling the knative images. The secret must be created in the
+                          same namespace as the knative-eventing deployments, and not the namespace of this resource.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              description: The name of the secret.
+                              type: string
+                type: object
+              status:
+                properties:
+                  version:
+                    description: The version of the installed release
+                    type: string
+                type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: knativeservings.operator.knative.dev
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .status.version
+          name: Version
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+        group: operator.knative.dev
+        names:
+          kind: KnativeServing
+          listKind: KnativeServingList
+          plural: knativeservings
+          shortNames:
+          - ks
+          singular: knativeserving
+        preserveUnknownFields: false
+        scope: Namespaced
+        subresources:
+          status: {}
+        validation:
+          openAPIV3Schema:
+            type: object
+            description: Schema for the knativeservings API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec defines the desired state of KnativeServing
+                properties:
+                  cluster-local-gateway:
+                    description: A means to override the cluster-local-gateway
+                    properties:
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: The selector for the ingress-gateway.
+                        type: object
+                    type: object
+                  config:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: A means to override the corresponding entries in the upstream
+                      configmaps
+                    type: object
+                  controller-custom-certs:
+                    description: Enabling the controller to trust registries with self-signed
+                      certificates
+                    properties:
+                      name:
+                        description: The name of the ConfigMap or Secret
+                        type: string
+                      type:
+                        description: One of ConfigMap or Secret
+                        enum:
+                        - ConfigMap
+                        - Secret
+                        - ""
+                        type: string
+                    type: object
+                  knative-ingress-gateway:
+                    description: A means to override the knative-ingress-gateway
+                    properties:
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: The selector for the ingress-gateway.
+                        type: object
+                    type: object
+                  registry:
+                    description: A means to override the corresponding deployment images
+                      in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                    properties:
+                      default:
+                        description: The default image reference template to use for all
+                          knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                        type: string
+                      imagePullSecrets:
+                        description: A list of secrets to be used when pulling the knative
+                          images. The secret must be created in the same namespace as the
+                          knative-serving deployments, and not the namespace of this resource.
+                        items:
+                          properties:
+                            name:
+                              description: The name of the secret.
+                              type: string
+                          type: object
+                        type: array
+                      override:
+                        additionalProperties:
+                          type: string
+                        description: A map of a container name or image name to the full
+                          image location of the individual knative image.
+                        type: object
+                    type: object
+                  high-availability:
+                    description: Allows specification of HA control plane
+                    type: object
+                    properties:
+                      replicas:
+                        description: The number of replicas that HA parts of the control plane will be scaled to
+                        type: integer
+                        minimum: 1
+                type: object
+              status:
+                description: Status defines the observed state of KnativeServing
+                properties:
+                  conditions:
+                    description: The latest available observations of a resource's current
+                      state.
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another. We use VolatileTime
+                            in place of metav1.Time to exclude this from creating equality.Semantic
+                            differences (all other things held constant).
+                          type: string
+                        message:
+                          description: A human readable message indicating details about
+                            the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        severity:
+                          description: Severity with which to treat failures of this type
+                            of condition. When this is not specified, it defaults to Error.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                      required:
+                      - type
+                      - status
+                      type: object
+                    type: array
+                  version:
+                    description: The version of the installed release
+                    type: string
+                type: object
+        version: v1alpha1
+        versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+  clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: |-
+            [
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeServing",
+                "metadata": {
+                  "name": "knative-serving"
+                },
+                "spec": {
+                }
+              },
+              {
+                "apiVersion": "operator.knative.dev/v1alpha1",
+                "kind": "KnativeEventing",
+                "metadata": {
+                  "name": "knative-eventing"
+                },
+                "spec": {
+                }
+              }
+            ]
+          capabilities: Full Lifecycle
+          categories: Networking,Integration & Delivery,Cloud Provider,Developer Tools
+          certified: "false"
+          createdAt: "2020-04-20T17:00:00Z"
+          description: |-
+            Provides a collection of API's based on Knative to support deploying and serving
+            of serverless applications and functions.
+          repository: https://github.com/openshift-knative/serverless-operator
+          support: Red Hat, Inc.
+        name: serverless-operator.v1.8.0
+        namespace: placeholder
+      spec:
+        apiservicedefinitions: {}
+        customresourcedefinitions:
+          owned:
+          - description: Represents an installation of a particular version of Knative Serving
+            displayName: Knative Serving
+            kind: KnativeServing
+            name: knativeservings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Serving installed
+              displayName: Version
+              path: version
+            - description: Conditions of Knative Serving installed
+              displayName: Conditions
+              path: conditions
+              x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+            version: v1alpha1
+          - description: Represents an installation of a particular version of Knative Eventing
+            displayName: Knative Eventing
+            kind: KnativeEventing
+            name: knativeeventings.operator.knative.dev
+            statusDescriptors:
+            - description: The version of Knative Eventing installed
+              displayName: Version
+              path: version
+            version: v1alpha1
+        minKubeVersion: 1.15.0
+        description: |-
+          The Red Hat OpenShift Serverless operator provides a collection of APIs that
+          enables containers, microservices and functions to run "serverless".
+          Serverless applications can scale up and down (to zero) on demand and be triggered by a
+          number of event sources. OpenShift Serverless integrates with a number of
+          platform services, such as Metering and Monitoring and it is based on the open
+          source project Knative.
+
+          # Prerequisites
+          The components provided with the OpenShift Serverless operator require minimum cluster sizes on
+          OpenShift Container Platform. For more information, see the documentation on [Getting started
+          with OpenShift Serverless](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started).
+
+          # Supported Features
+          - **Easy to get started:** Provides a simplified developer experience to deploy
+            and run cloud native applications on Kubernetes, providing powerful
+            abstractions.
+          - **Immutable Revisions:** Deploy new features performing canary, A/B or
+            blue-green testing with gradual traffic rollout following best practices.
+          - **Use any programming language or runtime of choice:** From Java, Python, Go
+            and JavaScript to Quarkus, SpringBoot or Node.js.
+          - **Automatic scaling:** Removes the requirement to configure numbers of replicas
+            or idling behavior. Applications automatically scale to zero when not in use,
+            or scale up to meet demand, with built in reliability and fault tolerance.
+          - **Event Driven Applications:** You can build loosely coupled, distributed applications
+            that can be connected to a variety of either built in or third party event sources,
+            powered by operators.
+          - **Ready for the hybrid cloud:** Provides true, portable serverless functionality,
+            that can run anywhere OpenShift Container Platform runs. You can leverage data
+            locality and SaaS as you need it.
+
+          # Components & APIs
+          This operator provides the following components:
+
+          ## Knative Serving
+          Knative Serving builds on Kubernetes to support deploying and serving of
+          applications and functions as serverless containers. Serving is easy to get
+          started with and scales to support advanced scenarios. Other features
+          includes:
+          - Rapid deployment of serverless containers
+          - Automatic scaling up and down to zero
+          - Routing and network programming
+          - Point-in-time snapshots of deployed code and configurations
+          ![](https://i.imgur.com/vqL48B8.png)
+
+          ## Knative Eventing
+
+          Knative Eventing is a **[Technology Preview feature](https://access.redhat.com/support/offerings/techpreview)!**
+
+          Knative Eventing is a system that is designed to address a common need for cloud native
+          development and provides composable primitives to enable late-binding event sources and
+          event consumers.
+          Knative Eventing is designed to address a common need for cloud
+          native development:
+          - Services are loosely coupled during development and deployed independently
+          - A producer can generate events before a consumer is listening, and a consumer
+             can express an interest in an event or class of events that is not yet being
+             produced.
+          - Services can be connected to create new applications
+             * without modifying producer or consumer, and
+             * with the ability to select a specific subset of events from a particular
+               producer.
+
+          ## Knative Client - `kn`
+          The Knative client `kn` is your door to the Knative world. It allows you to
+          create Knative resources interactively from the command line or from within
+          Shell scripts.
+
+          `kn` offers you:
+          - Full support for managing all features of Knative Serving (services,
+            revisions, traffic splits)
+          - Growing support Knative eventing, closely following its development
+            (managing of sources & triggers)
+          - A plugin architecture similar to that of kubectl plugins
+          - A thin client-specific API in golang which helps in tasks like synchronously
+            waiting on Knative service write operations.
+          - An easy integration of Knative into Tekton Pipelines by using kn in a Tekton
+            Task.
+
+          # Further Information
+          For documentation on OpenShift Serverless, see:
+          - [Installation
+          Guide](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/installing-openshift-serverless-1)
+          - [Getting
+          started](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/serverless-getting-started)
+        displayName: OpenShift Serverless Operator
+        icon:
+        - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMzQwMDt9LmNscy0ye2ZpbGw6I2NlMmUwMDt9LmNscy0ze2ZpbGw6bm9uZTt9LmNscy00e2ZpbGw6I2ZmZjt9LmNscy01e2ZpbGw6I2RjZGNkYzt9LmNscy02e2ZpbGw6I2FhYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZF9IYXQtT3BlbnNoaWZ0NC1DYXRhbG9nX0ljb25zLVNlcnZlcmxlc3M8L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik00MC41Nyw0Ny40MmEzLjg5LDMuODksMCwxLDAsMy44OCwzLjg4QTMuODksMy44OSwwLDAsMCw0MC41Nyw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0yMS40Miw0Ny40MkEzLjg5LDMuODksMCwxLDAsMjUuMyw1MS4zLDMuODksMy44OSwwLDAsMCwyMS40Miw0Ny40MloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC4wOSw0OC44NmgtLjE4YTQuMTEsNC4xMSwwLDAsMS0zLjI2LTEuNjMsNy42OSw3LjY5LDAsMCwwLTEyLjE2LDAsNC4xMyw0LjEzLDAsMCwxLTMuMjYsMS42M0gzMWE0LjA5LDQuMDksMCwwLDEtMy4yNS0xLjYzQTcuNjksNy42OSwwLDAsMCwxNCw1MS45M2gwVjY0LjZhMi43OSwyLjc5LDAsMCwwLDIuNzksMi43OWgxNS44TDUxLjM0LDQ4LjY2QTQsNCwwLDAsMSw1MC4wOSw0OC44NloiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik03OC4wNSw0NC4yNWE3LjY1LDcuNjUsMCwwLDAtNS44NSwzQTQuMSw0LjEsMCwwLDEsNjksNDguODZoLS4xOWE0LjEzLDQuMTMsMCwwLDEtMy4yNi0xLjYzLDcuNjksNy42OSwwLDAsMC0xMi4xNiwwLDQuMTYsNC4xNiwwLDAsMS0yLDEuNDNMMzIuNjEsNjcuMzlIODMuMTlBMi43OSwyLjc5LDAsMCwwLDg2LDY0LjZWNTIuMDdBNy43Nyw3Ljc3LDAsMCwwLDc4LjA1LDQ0LjI1WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTIxLjEsNjNoMTBhMS44MywxLjgzLDAsMSwwLDAtMy42NmgtMTBhMS44MywxLjgzLDAsMCwwLDAsMy42NloiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjQwLjU3IiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMjguMjMiIHI9IjEuMzUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjIxLjQyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjY4Ljg5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjMxLjA5IiBjeT0iNDMuNDUiIHI9IjIuOTMiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9Ijc3Ljk0IiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNiIgY3g9IjY4LjkxIiBjeT0iNTQuMzEiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9Ijc3Ljk0IiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjU5LjcyIiBjeT0iMzcuNzMiIHI9IjIuMTUiLz48Y2lyY2xlIGNsYXNzPSJjbHMtNCIgY3g9IjUwIiBjeT0iMzMuMSIgcj0iMy4wMSIvPjxjaXJjbGUgY2xhc3M9ImNscy00IiBjeD0iMzEuMDkiIGN5PSIzMy4xIiByPSIzLjAxIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTQiIGN4PSI2OC44OSIgY3k9IjMzLjEiIHI9IjMuMDEiLz48L3N2Zz4=
+          mediatype: image/svg+xml
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - '*'
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - events
+                - configmaps
+                verbs:
+                - "*"
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - replicasets
+                verbs:
+                - "*"
+              - apiGroups:
+                - apiextensions.k8s.io
+                resources:
+                - customresourcedefinitions
+                verbs:
+                - "*"
+              - apiGroups:
+                - networking.k8s.io
+                resources:
+                - networkpolicies
+                verbs:
+                - "*"
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - networking.internal.knative.dev
+                resources:
+                - clusteringresses
+                - clusteringresses/status
+                - clusteringresses/finalizers
+                - ingresses
+                - ingresses/status
+                - ingresses/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                - routes/custom-host
+                - routes/status
+                - routes/finalizers
+                verbs:
+                - "*"
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - knativeservings
+                - knativeservings/finalizers
+                verbs:
+                - '*'
+              serviceAccountName: knative-openshift-ingress
+            deployments:
+            - name: knative-serving-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-serving-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-serving-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-serving-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-serving-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-eventing-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-eventing-operator
+                template:
+                  metadata:
+                    annotations:
+                      sidecar.istio.io/inject: "false"
+                    labels:
+                      name: knative-eventing-operator
+                  spec:
+                    containers:
+                    - env:
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: knative-eventing-operator
+                      - name: SYSTEM_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: METRICS_DOMAIN
+                        value: knative.dev/eventing-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+                      imagePullPolicy: IfNotPresent
+                      name: knative-eventing-operator
+                      ports:
+                      - containerPort: 9090
+                        name: metrics
+                    serviceAccountName: knative-serving-operator
+            - name: knative-openshift
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift
+                      app: openshift-admission-server
+                  spec:
+                    serviceAccountName: knative-serving-operator
+                    containers:
+                      - name: knative-openshift
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        command:
+                        - knative-openshift
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: ""
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift"
+                          - name: MIN_OPENSHIFT_VERSION
+                            value: "4.3.0-0"
+                          - name: REQUIRED_SERVING_NAMESPACE
+                            value: "knative-serving"
+                          - name: REQUIRED_EVENTING_NAMESPACE
+                            value: "knative-eventing"
+                          - name: KOURIER_MANIFEST_PATH
+                            value: deploy/resources/kourier/kourier-latest.yaml
+                          - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
+                            value: deploy/resources/console_cli_download_kn_resources.yaml
+                          - name: IMAGE_queue-proxy
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+                          - name: IMAGE_activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+                          - name: IMAGE_autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+                          - name: IMAGE_autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+                          - name: IMAGE_controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+                          - name: IMAGE_webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+                          - name: IMAGE_3scale-kourier-gateway
+                            value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                          - name: IMAGE_3scale-kourier-control
+                            value: quay.io/3scale/kourier:fix_duplication
+                          - name: IMAGE_eventing-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
+                          - name: IMAGE_eventing-webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-webhook
+                          - name: IMAGE_broker-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-broker
+                          - name: IMAGE_imc-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-controller
+                          - name: IMAGE_imc-dispatcher
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+                          - name: IMAGE_CRONJOB_RA_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-cronjob-receive-adapter
+                          - name: IMAGE_PING_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ping
+                          - name: IMAGE_APISERVER_RA_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-apiserver-receive-adapter
+                          - name: IMAGE_BROKER_INGRESS_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ingress
+                          - name: IMAGE_BROKER_FILTER_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-filter
+                          - name: IMAGE_DISPATCHER_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+                          - name: IMAGE_KN_CLI_ARTIFACTS
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
+            - name: knative-openshift-ingress
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: knative-openshift-ingress
+                template:
+                  metadata:
+                    labels:
+                      name: knative-openshift-ingress
+                  spec:
+                    serviceAccountName: knative-openshift-ingress
+                    containers:
+                      - name: knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        command:
+                        - knative-openshift-ingress
+                        imagePullPolicy: Always
+                        env:
+                          - name: WATCH_NAMESPACE
+                            value: "" # watch all namespaces for ClusterIngress
+                          - name: POD_NAME
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: metadata.name
+                          - name: OPERATOR_NAME
+                            value: "knative-openshift-ingress"
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                verbs:
+                - '*'
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+                verbs:
+                - '*'
+              - apiGroups:
+                - monitoring.coreos.com
+                resources:
+                - servicemonitors
+                verbs:
+                - get
+                - create
+              - apiGroups:
+                - apps
+                resourceNames:
+                - knative-serving-operator
+                - knative-eventing-operator
+                resources:
+                - deployments/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - operator.knative.dev
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              serviceAccountName: knative-serving-operator
+          strategy: deployment
+        installModes:
+        - supported: false
+          type: OwnNamespace
+        - supported: false
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - serverless
+        - FaaS
+        - microservices
+        - scale to zero
+        - knative
+        - serving
+        - eventing
+        links:
+        - name: Documentation
+          url: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html/serverless_applications/index
+        - name: Source Repository
+          url: https://github.com/openshift-knative/serverless-operator
+        maintainers:
+        - email: serverless-support@redhat.com
+          name: Serverless Team
+        maturity: stable
+        provider:
+          name: Red Hat, Inc.
+        relatedImages:
+          - name: IMAGE_QUEUE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+          - name: IMAGE_activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+          - name: IMAGE_autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+          - name: IMAGE_autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+          - name: IMAGE_controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+          - name: IMAGE_webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+          - name: IMAGE_3scale-kourier-control
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kourier
+          - name: IMAGE_3scale-kourier-gateway
+            image: docker.io/maistra/proxyv2-ubi8:1.0.8
+          - name: knative-serving-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+          - name: knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+          - name: knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+          - name: knative-eventing-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+          - name: IMAGE_eventing-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
+          - name: IMAGE_eventing-webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-webhook
+          - name: IMAGE_broker-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-broker
+          - name: IMAGE_imc-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-controller
+          - name: IMAGE_imc-dispatcher
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+          - name: IMAGE_CRONJOB_RA_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-cronjob-receive-adapter
+          - name: IMAGE_PING_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ping
+          - name: IMAGE_APISERVER_RA_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-apiserver-receive-adapter
+          - name: IMAGE_BROKER_INGRESS_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ingress
+          - name: IMAGE_BROKER_FILTER_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-filter
+          - name: IMAGE_DISPATCHER_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+          - name: IMAGE_KN_CLI_ARTIFACTS
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
+        version: 1.8.0
+  packages: |-
+    - packageName: serverless-operator
+      defaultChannel: "preview-4.6"
+      channels:
+      - name: "preview-4.6"
+        currentCSV: serverless-operator.v1.8.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: serverless-operator
+spec:
+  configMap: serverless-operator
+  displayName: "Serverless Operator"
+  publisher: Red Hat
+  sourceType: internal

--- a/openshift/olm/minimum.package.yaml
+++ b/openshift/olm/minimum.package.yaml
@@ -1,0 +1,5 @@
+packageName: serverless-operator
+defaultChannel: "preview-4.6"
+channels:
+- name: "preview-4.6"
+  currentCSV: serverless-operator.v1.8.0

--- a/openshift/patches/001-object.patch
+++ b/openshift/patches/001-object.patch
@@ -1,0 +1,17 @@
+diff --git a/vendor/knative.dev/pkg/test/helpers/name.go b/vendor/knative.dev/pkg/test/helpers/name.go
+index 7bf14a3bf..b2ba6c146 100644
+--- a/vendor/knative.dev/pkg/test/helpers/name.go
++++ b/vendor/knative.dev/pkg/test/helpers/name.go
+@@ -48,7 +48,11 @@ func ObjectPrefixForTest(t test.T) string {
+ 
+ // ObjectNameForTest generates a random object name based on the test name.
+ func ObjectNameForTest(t test.T) string {
+-	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
++	prefix := ObjectPrefixForTest(t)
++	if len(prefix) > 20 {
++		prefix = prefix[:20]
++	}
++	return kmeta.ChildName(prefix, string(sep)+RandomString())
+ }
+ 
+ // AppendRandomString will generate a random string that begins with prefix.

--- a/openshift/patches/003-routeretry.patch
+++ b/openshift/patches/003-routeretry.patch
@@ -1,0 +1,100 @@
+diff --git a/test/v1/route.go b/test/v1/route.go
+index 3419f1d77..faaebd4b5 100644
+--- a/test/v1/route.go
++++ b/test/v1/route.go
+@@ -19,6 +19,7 @@ package v1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
+@@ -114,8 +115,20 @@ func IsRouteNotReady(r *v1.Route) (bool, error) {
+ }
+ 
+ // RetryingRouteInconsistency retries common requests seen when creating a new route
++// - 404 until the route is propagated to the proxy
++// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
+ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
++	const neededSuccesses = 5
++	var successes int
+ 	return func(resp *spoof.Response) (bool, error) {
++		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
++			successes = 0
++			return false, nil
++		}
++		successes++
++		if successes < neededSuccesses {
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}
+diff --git a/test/v1alpha1/route.go b/test/v1alpha1/route.go
+index 87406b63e..dbbe4840e 100644
+--- a/test/v1alpha1/route.go
++++ b/test/v1alpha1/route.go
+@@ -21,6 +21,7 @@ package v1alpha1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
+@@ -50,9 +51,20 @@ func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, f
+ }
+ 
+ // RetryingRouteInconsistency retries common requests seen when creating a new route
+-// TODO(5573): Remove this.
++// - 404 until the route is propagated to the proxy
++// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
+ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
++	const neededSuccesses = 5
++	var successes int
+ 	return func(resp *spoof.Response) (bool, error) {
++		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
++			successes = 0
++			return false, nil
++		}
++		successes++
++		if successes < neededSuccesses {
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}
+diff --git a/test/v1beta1/route.go b/test/v1beta1/route.go
+index 119b4a818..edc2b908d 100644
+--- a/test/v1beta1/route.go
++++ b/test/v1beta1/route.go
+@@ -19,6 +19,7 @@ package v1beta1
+ import (
+ 	"context"
+ 	"fmt"
++	"net/http"
+ 
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/util/wait"
+@@ -116,8 +117,20 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
+ }
+ 
+ // RetryingRouteInconsistency retries common requests seen when creating a new route
++// - 404 until the route is propagated to the proxy
++// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
+ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
++	const neededSuccesses = 5
++	var successes int
+ 	return func(resp *spoof.Response) (bool, error) {
++		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
++			successes = 0
++			return false, nil
++		}
++		successes++
++		if successes < neededSuccesses {
++			return false, nil
++		}
+ 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
+ 		return innerCheck(resp)
+ 	}

--- a/openshift/patches/004-grpc.patch
+++ b/openshift/patches/004-grpc.patch
@@ -1,0 +1,29 @@
+diff --git a/test/e2e/grpc_test.go b/test/e2e/grpc_test.go
+index ee9b45a6e..0aa1b9da5 100644
+--- a/test/e2e/grpc_test.go
++++ b/test/e2e/grpc_test.go
+@@ -323,6 +323,7 @@ func streamTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.C
+ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
+ 	t.Helper()
+ 	t.Parallel()
++	resolvable := false
+ 	cancel := logstream.Start(t)
+ 	defer cancel()
+ 
+@@ -352,14 +353,14 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
+ 		url,
+ 		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+ 		"gRPCPingReadyToServe",
+-		test.ServingFlags.ResolvableDomain,
++		resolvable,
+ 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
+ 	); err != nil {
+ 		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
+ 	}
+ 
+ 	host := url.Host
+-	if !test.ServingFlags.ResolvableDomain {
++	if !resolvable {
+ 		host = pkgTest.Flags.IngressEndpoint
+ 		if pkgTest.Flags.IngressEndpoint == "" {
+ 			host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -1,0 +1,35 @@
+# Release creation
+
+## Branching
+
+As far as branching goes, we have two use-cases:
+
+1. Creating a branch based off an upstream release tag.
+2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
+
+A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
+that points to the upstream repository and a remote "openshift" that points to the openshift fork.
+
+Run the scripts from the root of the repository.
+
+### Creating a branch based off an upstream release tag
+
+To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
+
+```bash
+$ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
+```
+
+This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
+files that we need to run CI on top of it.
+
+### Updating the release-next branch that follow upstream's HEAD
+
+To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
+
+```bash
+$ ./openshift/release/update-to-head.sh
+```
+
+That will pull the latest master from upstream, rebase the current fixes on the release-next branch
+on top of it, update the Openshift specific files if necessary, and then trigger CI.

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+# Usage: create-release-branch.sh v0.4.1 release-v0.4.1
+
+release=$1
+target=$2
+release_regexp="^release-v([0-9]+\.)+([0-9])$"
+
+if [[ ! $target =~ $release_regexp ]]; then
+    echo "\"$target\" is wrong format. Must have proper format like release-v0.1.2"
+    exit 1
+fi
+
+# Fetch the latest tags and checkout a new branch from the wanted tag.
+git fetch upstream --tags
+git checkout -b "$target" "$release"
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
+make generate-dockerfiles
+make generate-p12n-dockerfiles
+make RELEASE=$release generate-release
+make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m "Add openshift specific files."

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/resolve.sh
+
+release=$1
+output_file="openshift/release/knative-serving-${release}.yaml"
+
+if [ "$release" = "ci" ]; then
+    image_prefix="image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-"
+    tag=""
+else
+    image_prefix="quay.io/openshift-knative/knative-serving-"
+    tag=$release
+fi
+
+resolve_resources config/ "$output_file" "$image_prefix" "$tag"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -1,0 +1,1413 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    istio-injection: enabled
+    serving.knative.dev/release: devel
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-addressable-resolver
+  labels:
+    serving.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-server-resources
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+rules:
+  - apiGroups: ["custom.metrics.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-core
+  labels:
+    serving.knative.dev/release: devel
+    serving.knative.dev/controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
+    verbs: ["create"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["serving.knative.dev", "autoscaling.internal.knative.dev", "networking.internal.knative.dev"]
+    resources: ["*", "*/status", "*/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+  - apiGroups: ["caching.internal.knative.dev"]
+    resources: ["images"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-podspecable-binding
+  labels:
+    serving.knative.dev/release: devel
+    duck.knative.dev/podspecable: "true"
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - configurations
+  - services
+  verbs:
+  - list
+  - watch
+  - patch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-admin
+  labels:
+    serving.knative.dev/release: devel
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      serving.knative.dev/controller: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-controller-admin
+  labels:
+    serving.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics:system:auth-delegator
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-custom-metrics
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: custom-metrics-auth-reader
+  namespace: kube-system
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kcert
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: true
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - config
+    - cfg
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: Ingress
+    plural: ingresses
+    singular: ingress
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kingress
+    - king
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Metric
+    plural: metrics
+    singular: metric
+    categories:
+    - knative-internal
+    - autoscaling
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: PodAutoscaler
+    plural: podautoscalers
+    singular: podautoscaler
+    categories:
+    - knative-internal
+    - autoscaling
+    shortNames:
+    - kpa
+    - pa
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: DesiredScale
+    type: integer
+    JSONPath: ".status.desiredScale"
+  - name: ActualScale
+    type: integer
+    JSONPath: ".status.actualScale"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: true
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rev
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: Config Name
+    type: string
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+  - name: K8s Service Name
+    type: string
+    JSONPath: ".status.serviceName"
+  - name: Generation
+    type: string # int in string form :(
+    JSONPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: true
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rt
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: true
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - kservice
+    - ksvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - sks
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Mode
+    type: string
+    JSONPath: ".spec.mode"
+  - name: Activators
+    type: integer
+    JSONPath: ".spec.numActivators"
+  - name: ServiceName
+    type: string
+    JSONPath: ".status.serviceName"
+  - name: PrivateServiceName
+    type: string
+    JSONPath: ".status.privateServiceName"
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: config.webhook.serving.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: webhook.serving.knative.dev
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: validation.webhook.serving.knative.dev
+  timeoutSeconds: 10
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+---
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  name: queue-proxy
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  image: ko://knative.dev/serving/cmd/queue
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  minReplicas: 1
+  maxReplicas: 20
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: activator
+      role: activator
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: activator
+        role: activator
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: activator
+        image: ko://knative.dev/serving/cmd/activator
+        resources:
+          requests:
+            cpu: 300m
+            memory: 60Mi
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+        env:
+        - name: GOGC
+          value: "500"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: http1
+          containerPort: 8012
+        - name: h2c
+          containerPort: 8013
+        readinessProbe: &probe
+          httpGet:
+            port: 8012
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "activator"
+          failureThreshold: 12
+        livenessProbe: *probe
+      terminationGracePeriodSeconds: 300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: activator-service
+  namespace: knative-serving
+  labels:
+    app: activator
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    app: activator
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: http
+    port: 80
+    targetPort: 8012
+  - name: http2
+    port: 81
+    targetPort: 8013
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler-hpa
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/autoscaler-provider: hpa
+spec:
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: autoscaler-hpa
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler-hpa
+        image: ko://knative.dev/serving/cmd/autoscaler-hpa
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler-hpa
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/autoscaler-provider: hpa
+  name: autoscaler-hpa
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: autoscaler-hpa
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: autoscaler
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler
+        image: ko://knative.dev/serving/cmd/autoscaler
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: websocket
+          containerPort: 8080
+        - name: custom-metrics
+          containerPort: 8443
+        readinessProbe: &probe
+          httpGet:
+            port: 8080
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "autoscaler"
+        livenessProbe: *probe
+        args:
+        - "--secure-port=8443"
+        - "--cert-dir=/tmp"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler
+    serving.knative.dev/release: devel
+  name: autoscaler
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: http
+    port: 8080
+    targetPort: 8080
+  - name: https-custom-metrics
+    port: 443
+    targetPort: 8443
+  selector:
+    app: autoscaler
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: "62090295"
+data:
+  _example: |
+    container-concurrency-target-percentage: "70"
+    container-concurrency-target-default: "100"
+    requests-per-second-target-default: "200"
+    target-burst-capacity: "200"
+    stable-window: "60s"
+    panic-window-percentage: "10.0"
+    panic-threshold-percentage: "200.0"
+    max-scale-up-rate: "1000.0"
+    max-scale-down-rate: "2.0"
+    enable-scale-to-zero: "true"
+    scale-to-zero-grace-period: "30s"
+    scale-to-zero-pod-retention-period: "0s"
+    enable-graceful-scaledown: "false"
+    pod-autoscaler-class: "kpa.autoscaling.knative.dev"
+    activator-capacity: "100.0"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: c3699c6c
+data:
+  _example: |
+    revision-timeout-seconds: "300"  # 5 minutes
+    max-revision-timeout-seconds: "600"  # 10 minutes
+    revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+    revision-memory-request: "100M"  # 100 megabytes of memory
+    revision-ephemeral-storage-request: "500M"  # 500 megabytes of storage
+    revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+    revision-memory-limit: "200M"  # 200 megabytes of memory
+    revision-ephemeral-storage-limit: "750M"  # 750 megabytes of storage
+    container-name-template: "user-container"
+    container-concurrency: "0"
+    container-concurrency-max-limit: "1000"
+    allow-container-concurrency-zero: "true"
+    enable-multi-container: "false"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-deployment
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: 3d5b261a
+data:
+  queueSidecarImage: ko://knative.dev/serving/cmd/queue
+  _example: |
+    registriesSkippingTagResolving: "ko.local,dev.local"
+    progressDeadline: "120s"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: aa261100
+data:
+  _example: |
+    example.com: |
+    example.org: |
+      selector:
+        app: nonprofit
+    svc.cluster.local: |
+      selector:
+        app: secret
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: 84c3c6c3
+data:
+  _example: |
+    multi-container: "disabled"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gc
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: eb64daa7
+data:
+  _example: |
+    stale-revision-create-delay: "48h"
+    stale-revision-timeout: "15h"
+    stale-revision-minimum-generations: "20"
+    stale-revision-lastpinned-debounce: "5h"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: c517f87a
+data:
+  _example: |
+    resourceLock: "leases"
+    leaseDuration: "15s"
+    renewDeadline: "10s"
+    retryPeriod: "2s"
+    enabledComponents: "controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: f83a0082
+data:
+  _example: |
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+    loglevel.hpaautoscaler: "info"
+    loglevel.certcontroller: "info"
+    loglevel.istiocontroller: "info"
+    loglevel.nscontroller: "info"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: fe214c76
+data:
+  _example: |
+    ingress.class: "istio.ingress.networking.knative.dev"
+    certificate.class: "cert-manager.certificate.networking.knative.dev"
+    domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+    tagTemplate: "{{.Tag}}-{{.Name}}"
+    autoTLS: "Disabled"
+    httpProtocol: "Enabled"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: 5ec1a71c
+data:
+  _example: |
+    logging.enable-var-log-collection: "false"
+    logging.revision-url-template: |
+      http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+    logging.enable-probe-request-log: "false"
+    metrics.backend-destination: prometheus
+    metrics.request-metrics-backend-destination: prometheus
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    metrics.allow-stackdriver-custom-metrics: "false"
+    profiling.enable: "false"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+  annotations:
+    knative.dev/example-checksum: 35dc6aa4
+data:
+  _example: |
+    backend: "none"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+    stackdriver-project-id: "my-project"
+    debug: "false"
+    sample-rate: "0.1"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: controller
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: controller
+        image: ko://knative.dev/serving/cmd/controller
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+    serving.knative.dev/release: devel
+  name: controller
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: controller
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+  labels:
+    serving.knative.dev/release: devel
+    autoscaling.knative.dev/metric-provider: custom-metrics
+spec:
+  service:
+    name: autoscaler
+    namespace: knative-serving
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: webhook
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: webhook
+        role: webhook
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: webhook
+        image: ko://knative.dev/serving/cmd/webhook
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: WEBHOOK_PORT
+          value: "8443"
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        livenessProbe: *probe
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: webhook
+    serving.knative.dev/release: devel
+  name: webhook
+  namespace: knative-serving
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    role: webhook

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+function resolve_resources(){
+  local dir=$1
+  local resolved_file_name=$2
+  local image_prefix=$3
+  local image_tag=$4
+
+  [[ -n $image_tag ]] && image_tag=":$image_tag"
+
+  echo "Writing resolved yaml to $resolved_file_name"
+
+  > "$resolved_file_name"
+
+  for yaml in "$dir"/*.yaml; do
+    resolve_file "$yaml" "$resolved_file_name" "$image_prefix" "$image_tag"
+  done
+}
+
+function resolve_file() {
+  local file=$1
+  local to=$2
+  local image_prefix=$3
+  local image_tag=$4
+
+  # Skip cert-manager, it's not part of upstream's release YAML either.
+  if grep -q 'networking.knative.dev/certificate-provider: cert-manager' "$1"; then
+    return
+  fi
+
+  # Skip nscert, it's not part of upstream's release YAML either.
+  if grep -q 'networking.knative.dev/wildcard-certificate-provider: nscert' "$1"; then
+    return
+  fi
+
+  # Skip istio resources, as we use kourier.
+  if grep -q 'networking.knative.dev/ingress-provider: istio' "$1"; then
+    return
+  fi
+
+  echo "---" >> "$to"
+  # 1. Rewrite image references
+  # 2. Update config map entry
+  # 3. Remove comment lines
+  # 4. Remove empty lines
+  sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
+      -e "s+\(.* queueSidecarImage: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
+      -e '/^[ \t]*#/d' \
+      -e '/^[ \t]*$/d' \
+      "$file" >> "$to"
+}

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
+
+set -e
+REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+
+# Reset release-next to upstream/master.
+git fetch upstream master
+git checkout upstream/master -B release-next
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
+make generate-dockerfiles
+make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m ":open_file_folder: Update openshift specific files."
+
+# Apply patches .
+git apply openshift/patches/*
+git commit -am ":fire: Apply carried patches."
+
+git push -f openshift release-next
+
+# Trigger CI
+git checkout release-next -B release-next-ci
+date > ci
+git add ci
+git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/master"
+git push -f openshift release-next-ci
+
+if hash hub 2>/dev/null; then
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+else
+   echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
+fi

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -322,6 +322,7 @@ func streamTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.C
 func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Helper()
 	t.Parallel()
+	resolvable := false
 	cancel := logstream.Start(t)
 	defer cancel()
 
@@ -351,14 +352,14 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		url,
 		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"gRPCPingReadyToServe",
-		test.ServingFlags.ResolvableDomain,
+		resolvable,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
 	); err != nil {
 		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
 	}
 
 	host := url.Host
-	if !test.ServingFlags.ResolvableDomain {
+	if !resolvable {
 		host = pkgTest.Flags.IngressEndpoint
 		if pkgTest.Flags.IngressEndpoint == "" {
 			host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -115,8 +116,20 @@ func IsRouteNotReady(r *v1.Route) (bool, error) {
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
+// - 404 until the route is propagated to the proxy
+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+	const neededSuccesses = 5
+	var successes int
 	return func(resp *spoof.Response) (bool, error) {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			successes = 0
+			return false, nil
+		}
+		successes++
+		if successes < neededSuccesses {
+			return false, nil
+		}
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -51,9 +52,20 @@ func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, f
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
-// TODO(5573): Remove this.
+// - 404 until the route is propagated to the proxy
+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+	const neededSuccesses = 5
+	var successes int
 	return func(resp *spoof.Response) (bool, error) {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			successes = 0
+			return false, nil
+		}
+		successes++
+		if successes < neededSuccesses {
+			return false, nil
+		}
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -117,8 +118,20 @@ func IsRouteFailed(r *v1beta1.Route) (bool, error) {
 }
 
 // RetryingRouteInconsistency retries common requests seen when creating a new route
+// - 404 until the route is propagated to the proxy
+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
 func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
+	const neededSuccesses = 5
+	var successes int
 	return func(resp *spoof.Response) (bool, error) {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
+			successes = 0
+			return false, nil
+		}
+		successes++
+		if successes < neededSuccesses {
+			return false, nil
+		}
 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
 		return innerCheck(resp)
 	}

--- a/vendor/knative.dev/pkg/test/helpers/name.go
+++ b/vendor/knative.dev/pkg/test/helpers/name.go
@@ -48,7 +48,11 @@ func ObjectPrefixForTest(t test.T) string {
 
 // ObjectNameForTest generates a random object name based on the test name.
 func ObjectNameForTest(t test.T) string {
-	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
+	prefix := ObjectPrefixForTest(t)
+	if len(prefix) > 20 {
+		prefix = prefix[:20]
+	}
+	return kmeta.ChildName(prefix, string(sep)+RandomString())
 }
 
 // AppendRandomString will generate a random string that begins with prefix.


### PR DESCRIPTION
The route URL appends namespace to the servicce name on OpenShift. So
the URL label becomes longer than 63 characters limit (RFC 1035) when
object is created based on the long test name.

(e.g.)
`TestRevisionTimeout/when_pods_already_exist,_and_it_writes_first_byte_before_timeout: revision_timeout_test.go:187: Error probing http://revision-timeout-when-2cf92cab92421bf161fd0f1d28b30377-okealkcs-serving-tests.apps.ci-op-rngdy02l-7b412.origin-ci-int-aws.dev.rhcloud.com: response: <nil> did not pass checks: timed out waiting for the condition`

To avoid it, this patch adds the length limit patch.
