### PR TITLE
Add object length limit patch

### DIFF
--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -514,7 +514,7 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
@@ -548,7 +548,7 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/eventing-operator
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-eventing-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-eventing-operator
                       ports:
@@ -594,21 +594,21 @@ data:
                           - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
                             value: deploy/resources/console_cli_download_kn_resources.yaml
                           - name: IMAGE_queue-proxy
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-queue
                           - name: IMAGE_activator
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-activator
                           - name: IMAGE_autoscaler
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler
                           - name: IMAGE_autoscaler-hpa
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler-hpa
                           - name: IMAGE_controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-controller
                           - name: IMAGE_webhook
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-webhook
                           - name: IMAGE_3scale-kourier-gateway
                             value: docker.io/maistra/proxyv2-ubi8:1.0.8
                           - name: IMAGE_3scale-kourier-control
-                            value: quay.io/3scale/kourier:fix_duplication
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:kourier
                           - name: IMAGE_eventing-controller
                             value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
                           - name: IMAGE_eventing-webhook
@@ -743,29 +743,29 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-queue
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-queue
           - name: IMAGE_activator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-activator
           - name: IMAGE_autoscaler
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler
           - name: IMAGE_autoscaler-hpa
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler-hpa
           - name: IMAGE_controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-controller
           - name: IMAGE_webhook
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-webhook
           - name: IMAGE_3scale-kourier-control
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kourier
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:kourier
           - name: IMAGE_3scale-kourier-gateway
             image: docker.io/maistra/proxyv2-ubi8:1.0.8
           - name: knative-serving-operator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-serving-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-operator
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
           - name: knative-eventing-operator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:knative-eventing-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-eventing-operator
           - name: IMAGE_eventing-controller
             image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
           - name: IMAGE_eventing-webhook

--- a/openshift/patches/001-object.patch
+++ b/openshift/patches/001-object.patch
@@ -1,0 +1,17 @@
+diff --git a/vendor/knative.dev/pkg/test/helpers/name.go b/vendor/knative.dev/pkg/test/helpers/name.go
+index 7bf14a3bf..b2ba6c146 100644
+--- a/vendor/knative.dev/pkg/test/helpers/name.go
++++ b/vendor/knative.dev/pkg/test/helpers/name.go
+@@ -48,7 +48,11 @@ func ObjectPrefixForTest(t test.T) string {
+ 
+ // ObjectNameForTest generates a random object name based on the test name.
+ func ObjectNameForTest(t test.T) string {
+-	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
++	prefix := ObjectPrefixForTest(t)
++	if len(prefix) > 20 {
++		prefix = prefix[:20]
++	}
++	return kmeta.ChildName(prefix, string(sep)+RandomString())
+ }
+ 
+ // AppendRandomString will generate a random string that begins with prefix.


### PR DESCRIPTION
The route URL appends namespace to the servicce name on OpenShift. So
the URL label becomes longer than 63 characters limit (RFC 1035) when
object is created based on the long test name.

(e.g.)
`TestRevisionTimeout/when_pods_already_exist,_and_it_writes_first_byte_before_timeout: revision_timeout_test.go:187: Error probing http://revision-timeout-when-2cf92cab92421bf161fd0f1d28b30377-okealkcs-serving-tests.apps.ci-op-rngdy02l-7b412.origin-ci-int-aws.dev.rhcloud.com: response: <nil> did not pass checks: timed out waiting for the condition`

To avoid it, this patch adds the length limit patch.