### PR TITLE
Improve dev experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 CGO_ENABLED=0
 GOOS=linux
 CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/nscert
-TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) 
+TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d)
+DOCKER_REPO_OVERRIDE=
+BRANCH=
+TEST=
+IMAGE=
 
 install:
 	for img in $(CORE_IMAGES); do \
@@ -18,8 +22,29 @@ test-install:
 .PHONY: test-install
 
 test-e2e:
-	./openshift/e2e-tests-openshift.sh
+	./openshift/e2e-tests.sh
 .PHONY: test-e2e
+
+test-images:
+	for img in $(TEST_IMAGES); do \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=latest -RBf $$img ; \
+	done
+.PHONY: test-image-all
+
+test-image-single:
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=latest -RBf test/test_images/$(IMAGE)
+.PHONY: test-image
+
+# Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available
+# in the given repository. Make sure you first build and push them there by running `make test-images`.
+# Run make BRANCH=<ci_promotion_name> test-e2e-local if test images from the latest CI
+# build for this branch should be used. Example: `make BRANCH=knative-v0.13.2 test-e2e-local`.
+# If neither DOCKER_REPO_OVERRIDE nor BRANCH are defined the tests will use test images
+# from the last nightly build.
+# If TEST is defined then only the single test will be run.
+test-e2e-local:
+	./openshift/e2e-tests-local.sh $(TEST)
+.PHONY: test-e2e-local
 
 # Generate Dockerfiles for core and test images used by ci-operator. The files need to be committed manually.
 generate-dockerfiles:

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -18,6 +18,8 @@ elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
   readonly TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
 elif [ -n "$BRANCH" ]; then
   readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/${BRANCH}:knative-serving-test-{{.Name}}"
+elif [ -n "$TEMPLATE" ]; then
+  readonly TEST_IMAGE_TEMPLATE="$TEMPLATE"
 else
   readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-serving-test-{{.Name}}"
 fi

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -4,18 +4,23 @@
 source "$(dirname "$0")/../test/e2e-common.sh"
 source "$(dirname "$0")/release/resolve.sh"
 
-set -x
-
 readonly SERVING_NAMESPACE=knative-serving
 readonly SERVING_INGRESS_NAMESPACE=knative-serving-ingress
-
-# A golang template to point the tests to the right image coordinates.
-# {{.Name}} is the name of the image, for example 'autoscale'.
-readonly TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-serving-test-{{.Name}}}"
 
 # The OLM global namespace was moved to openshift-marketplace since v4.2
 # ref: https://jira.coreos.com/browse/OLM-1190
 readonly OLM_NAMESPACE="openshift-marketplace"
+
+# Determine if we're running locally or in CI.
+if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
+  readonly TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-serving-test-{{.Name}}}"
+elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
+  readonly TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
+elif [ -n "$BRANCH" ]; then
+  readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/${BRANCH}:knative-serving-test-{{.Name}}"
+else
+  readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-serving-test-{{.Name}}"
+fi
 
 env
 
@@ -152,53 +157,76 @@ spec:
 EOF
 }
 
-function run_e2e_tests(){
+function prepare_knative_serving_tests {
   echo ">> Creating test resources for OpenShift (test/config/)"
+
   oc apply -f test/config
 
   oc adm policy add-scc-to-user privileged -z default -n serving-tests
   oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
-  # adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
+  # Adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
 
-  header "Running tests"
-  failed=0
-
-  export SYSTEM_NAMESPACE="knative-serving"
+  export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
   export GATEWAY_OVERRIDE=kourier
   export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
   export INGRESS_CLASS=kourier.ingress.networking.knative.dev
+}
 
-  report_go_test \
-    -v -tags=e2e -count=1 -timeout=35m -short -parallel=3 \
-    ./test/e2e \
+function run_e2e_tests(){
+  header "Running tests"
+
+  local test_name=$1 
+  local failed=0
+
+  if [ -n "$test_name" ]; then
+    go_test_e2e -tags=e2e -timeout=15m -parallel=1 \
+    ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
+    -run "^(${test_name})$" \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
-    --resolvabledomain || failed=1
+    --resolvabledomain "$(ingress_class)" || failed=$?
 
-  report_go_test \
-    -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
-    ./test/conformance/runtime/... \
+    return $failed
+  fi
+
+  local parallel=3
+
+  if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
+    # Since we don't have LoadBalancers working, gRPC tests will always fail.
+    rm ./test/e2e/grpc_test.go
+    parallel=2
+  fi
+
+  go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
+    ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --resolvabledomain "$(ingress_class)" || failed=1
 
-  report_go_test \
-    -v -tags=e2e -count=1 -timeout=35m -parallel=3 \
-    ./test/conformance/api/... \
+ # Run the helloworld test with an image pulled into the internal registry.
+  local image_to_tag=$(echo "$TEST_IMAGE_TEMPLATE" | sed 's/\(.*\){{.Name}}\(.*\)/\1helloworld\2/')
+  oc tag -n serving-tests "$image_to_tag" "helloworld:latest" --reference-policy=local
+  go_test_e2e -tags=e2e -timeout=30m ./test/e2e -run "^(TestHelloWorld)$" \
+    --resolvabledomain --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "image-registry.openshift-image-registry.svc:5000/serving-tests/{{.Name}}" || failed=2
+
+  # Prevent HPA from scaling to make the tests more stable
+  oc -n "$SERVING_NAMESPACE" patch hpa activator \
+  --type 'merge' \
+  --patch '{"spec": {"maxReplicas": '2', "minReplicas": '2'}}' || return 1
+
+  # Give the controller time to sync with the rest of the system components.
+  sleep 30
+
+  # Use sed as the -spoofinterval parameter is not available yet
+  sed "s/\(.*requestInterval =\).*/\1 10 * time.Millisecond/" -i vendor/knative.dev/pkg/test/spoof/spoof.go
+
+  go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 \
+    ./test/ha \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
-    --resolvabledomain "$(ingress_class)" || failed=1
+    --resolvabledomain "$(ingress_class)"|| failed=3
 
   return $failed
 }
-
-scale_up_workers || exit 1
-
-failed=0
-(( !failed )) && install_knative || failed=1
-(( !failed )) && run_e2e_tests || failed=1
-(( failed )) && dump_cluster_state
-(( failed )) && exit 1
-
-success

--- a/openshift/e2e-tests-local.sh
+++ b/openshift/e2e-tests-local.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/e2e-common.sh"
+
+set -x
+
+env
+
+failed=0
+
+(( !failed )) && prepare_knative_serving_tests || failed=1
+(( !failed )) && run_e2e_tests "$TEST" || failed=2
+(( failed )) && dump_cluster_state
+(( failed )) && exit $failed
+
+success

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/e2e-common.sh"
+
+set -x
+
+env
+
+scale_up_workers || exit $?
+
+failed=0
+
+(( !failed )) && install_knative || failed=1
+(( !failed )) && prepare_knative_serving_tests || failed=2
+(( !failed )) && run_e2e_tests || failed=3
+(( failed )) && dump_cluster_state
+(( failed )) && exit $failed
+
+success


### PR DESCRIPTION
Make it easier to do these:
* build all test images
* build a single test image
* run the whole test suite
* run a single test

This is same as we already have on master and 0.13.3 branch