### PR TITLE
Update catalogsrouce to update kourier version

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -96,6 +96,13 @@ function install_knative(){
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-controller|${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}|g"         ${CATALOG_SOURCE}
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-webhook|${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}|g"               ${CATALOG_SOURCE}
 
+  # Replace kourier's image with the latest ones from third_party/kourier-latest
+  KOURIER_CONTROL=$(grep -w "gcr.io/knative-nightly/knative.dev/net-kourier/cmd/kourier" third_party/kourier-latest/kourier.yaml  | awk '{print $NF}')
+  KOURIER_GATEWAY=$(grep -w "docker.io/maistra/proxyv2-ubi8" third_party/kourier-latest/kourier.yaml  | awk '{print $NF}')
+
+  sed -i -e "s|docker.io/maistra/proxyv2-ubi8:*|${KOURIER_GATEWAY}|g"                                         ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:kourier|${KOURIER_CONTROL}|g"               ${CATALOG_SOURCE}
+
   # release-next branch keeps updating the latest manifest in knative-serving-ci.yaml for serving resources.
   # see: https://github.com/openshift/knative-serving/blob/release-next/openshift/release/knative-serving-ci.yaml
   # So mount the manifest and use it by KO_DATA_PATH env value.
@@ -137,6 +144,9 @@ function deploy_serverless_operator(){
 
   # Create configmap to use the latest manifest.
   oc create configmap ko-data -n $operator_ns --from-file="openshift/release/knative-serving-ci.yaml"
+
+  # Create configmap to use the latest kourier.
+  oc create configmap kourier-cm -n $operator_ns --from-file="third_party/kourier-latest/kourier.yaml"
 
   cat <<-EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -100,7 +100,7 @@ function install_knative(){
   KOURIER_CONTROL=$(grep -w "gcr.io/knative-nightly/knative.dev/net-kourier/cmd/kourier" third_party/kourier-latest/kourier.yaml  | awk '{print $NF}')
   KOURIER_GATEWAY=$(grep -w "docker.io/maistra/proxyv2-ubi8" third_party/kourier-latest/kourier.yaml  | awk '{print $NF}')
 
-  sed -i -e "s|docker.io/maistra/proxyv2-ubi8:*|${KOURIER_GATEWAY}|g"                                         ${CATALOG_SOURCE}
+  sed -i -e "s|docker.io/maistra/proxyv2-ubi8:.*|${KOURIER_GATEWAY}|g"                                         ${CATALOG_SOURCE}
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:kourier|${KOURIER_CONTROL}|g"               ${CATALOG_SOURCE}
 
   # release-next branch keeps updating the latest manifest in knative-serving-ci.yaml for serving resources.

--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -1,6 +1,8 @@
---- knative-serving.catalogsource.yaml.org	2020-04-24 18:07:55.175291572 +0900
-+++ knative-serving.catalogsource.yaml	2020-04-24 18:08:16.631512089 +0900
-@@ -506,6 +506,8 @@
+diff --git a/openshift/olm/knative-serving.catalogsource.yaml b/openshift/olm/knative-serving.catalogsource.yaml
+index 129615a3f..744375b50 100644
+--- a/openshift/olm/knative-serving.catalogsource.yaml
++++ b/openshift/olm/knative-serving.catalogsource.yaml
+@@ -518,6 +518,8 @@ data:
                          valueFrom:
                            fieldRef:
                              fieldPath: metadata.name
@@ -9,7 +11,7 @@
                        - name: OPERATOR_NAME
                          value: knative-serving-operator
                        - name: SYSTEM_NAMESPACE
-@@ -520,6 +522,16 @@
+@@ -532,6 +534,16 @@ data:
                        ports:
                        - containerPort: 9090
                          name: metrics
@@ -26,3 +28,32 @@
                      serviceAccountName: knative-serving-operator
              - name: knative-eventing-operator
                spec:
+@@ -579,9 +591,19 @@ data:
+                       name: knative-openshift
+                       app: openshift-admission-server
+                   spec:
++                    volumes:
++                    - name: kourier-manifest
++                      configMap:
++                        name: kourier-cm
++                        items:
++                        - key: kourier.yaml
++                          path: kourier.yaml
+                     serviceAccountName: knative-serving-operator
+                     containers:
+                       - name: knative-openshift
++                        volumeMounts:
++                        - mountPath: /tmp/kourier
++                          name: kourier-manifest
+                         image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                         command:
+                         - knative-openshift
+@@ -602,7 +624,7 @@ data:
+                           - name: REQUIRED_EVENTING_NAMESPACE
+                             value: "knative-eventing"
+                           - name: KOURIER_MANIFEST_PATH
+-                            value: deploy/resources/kourier/kourier-latest.yaml
++                            value: /tmp/kourier/kourier.yaml
+                           - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
+                             value: deploy/resources/console_cli_download_kn_resources.yaml
+                           - name: IMAGE_queue-proxy

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -47,6 +47,14 @@ data:
               spec:
                 description: Spec defines the desired state of KnativeEventing
                 properties:
+                  config:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: A means to override the corresponding entries in the upstream
+                      configmaps
+                    type: object
                   registry:
                     description: A means to override the corresponding deployment images in the upstream.
                       This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
@@ -71,6 +79,10 @@ data:
                             name:
                               description: The name of the secret.
                               type: string
+                  default-broker-class:
+                    description: The default broker type to use for the brokers Knative creates.
+                      If no value is provided, ChannelBasedBroker will be used.
+                    type: string
                 type: object
               status:
                 properties:
@@ -514,7 +526,7 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/serving-operator
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-serving-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-serving-operator
                       ports:
@@ -548,7 +560,7 @@ data:
                             fieldPath: metadata.namespace
                       - name: METRICS_DOMAIN
                         value: knative.dev/eventing-operator
-                      image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-eventing-operator
+                      image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-operator
                       imagePullPolicy: IfNotPresent
                       name: knative-eventing-operator
                       ports:
@@ -594,43 +606,51 @@ data:
                           - name: CONSOLECLIDOWNLOAD_MANIFEST_PATH
                             value: deploy/resources/console_cli_download_kn_resources.yaml
                           - name: IMAGE_queue-proxy
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-queue
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-queue
                           - name: IMAGE_activator
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-activator
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-activator
                           - name: IMAGE_autoscaler
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-autoscaler
                           - name: IMAGE_autoscaler-hpa
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler-hpa
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-autoscaler-hpa
                           - name: IMAGE_controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-controller
                           - name: IMAGE_webhook
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-webhook
                           - name: IMAGE_3scale-kourier-gateway
-                            value: docker.io/maistra/proxyv2-ubi8:1.0.8
+                            value: docker.io/maistra/proxyv2-ubi8:1.1.0
                           - name: IMAGE_3scale-kourier-control
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:kourier
-                          - name: IMAGE_eventing-controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
-                          - name: IMAGE_eventing-webhook
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-webhook
-                          - name: IMAGE_broker-controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-broker
-                          - name: IMAGE_imc-controller
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-controller
-                          - name: IMAGE_imc-dispatcher
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
-                          - name: IMAGE_CRONJOB_RA_IMAGE
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-cronjob-receive-adapter
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:kourier
+                          - name: IMAGE_eventing-controller__eventing-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-controller
+                          - name: IMAGE_eventing-webhook__eventing-webhook
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-webhook
+                          - name: IMAGE_broker-controller__eventing-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-broker
+                          - name: IMAGE_broker-filter__filter
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-mtbroker-filter
+                          - name: IMAGE_broker-ingress__ingress
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-mtbroker-ingress
+                          - name: IMAGE_mt-broker-controller__eventing-controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-mtchannel-broker
+                          - name: IMAGE_imc-controller__controller
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-controller
+                          - name: IMAGE_imc-dispatcher__dispatcher
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-dispatcher
+                          - name: IMAGE_v0.14.0-upgrade__upgrade-brokers
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-upgrade-v0-14-0
                           - name: IMAGE_PING_IMAGE
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ping
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-adapter
+                          - name: IMAGE_JOB_RUNNER_IMAGE
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-jobrunner
                           - name: IMAGE_APISERVER_RA_IMAGE
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-apiserver-receive-adapter
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-apiserver-receive-adapter
                           - name: IMAGE_BROKER_INGRESS_IMAGE
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ingress
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-broker-ingress
                           - name: IMAGE_BROKER_FILTER_IMAGE
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-filter
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-broker-filter
                           - name: IMAGE_DISPATCHER_IMAGE
-                            value: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+                            value: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-dispatcher
                           - name: IMAGE_KN_CLI_ARTIFACTS
                             value: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
             - name: knative-openshift-ingress
@@ -743,51 +763,59 @@ data:
           name: Red Hat, Inc.
         relatedImages:
           - name: IMAGE_QUEUE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-queue
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-queue
           - name: IMAGE_activator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-activator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-activator
           - name: IMAGE_autoscaler
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-autoscaler
           - name: IMAGE_autoscaler-hpa
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-autoscaler-hpa
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-autoscaler-hpa
           - name: IMAGE_controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-controller
           - name: IMAGE_webhook
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:knative-serving-webhook
           - name: IMAGE_3scale-kourier-control
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:kourier
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.1:kourier
           - name: IMAGE_3scale-kourier-gateway
-            image: docker.io/maistra/proxyv2-ubi8:1.0.8
+            image: docker.io/maistra/proxyv2-ubi8:1.1.0
           - name: knative-serving-operator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-serving-operator
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-serving-operator
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
           - name: knative-openshift-ingress
             image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
           - name: knative-eventing-operator
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.3:knative-eventing-operator
-          - name: IMAGE_eventing-controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-controller
-          - name: IMAGE_eventing-webhook
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-webhook
-          - name: IMAGE_broker-controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-broker
-          - name: IMAGE_imc-controller
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-controller
-          - name: IMAGE_imc-dispatcher
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
-          - name: IMAGE_CRONJOB_RA_IMAGE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-cronjob-receive-adapter
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-operator
+          - name: IMAGE_eventing-controller__eventing-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-controller
+          - name: IMAGE_eventing-webhook__eventing-webhook
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-webhook
+          - name: IMAGE_broker-controller__eventing-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-broker
+          - name: IMAGE_broker-filter__filter
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-mtbroker-filter
+          - name: IMAGE_broker-ingress__ingress
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-mtbroker-ingress
+          - name: IMAGE_mt-broker-controller__eventing-controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-mtchannel-broker
+          - name: IMAGE_imc-controller__controller
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-controller
+          - name: IMAGE_imc-dispatcher__dispatcher
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-dispatcher
+          - name: IMAGE_v0.14.0-upgrade__upgrade-brokers
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-upgrade-v0-14-0
           - name: IMAGE_PING_IMAGE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ping
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-adapter
+          - name: IMAGE_JOB_RUNNER_IMAGE
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-jobrunner
           - name: IMAGE_APISERVER_RA_IMAGE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-apiserver-receive-adapter
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-apiserver-receive-adapter
           - name: IMAGE_BROKER_INGRESS_IMAGE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-ingress
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-broker-ingress
           - name: IMAGE_BROKER_FILTER_IMAGE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-filter
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-broker-filter
           - name: IMAGE_DISPATCHER_IMAGE
-            image: registry.svc.ci.openshift.org/openshift/knative-v0.13.0:knative-eventing-channel-dispatcher
+            image: registry.svc.ci.openshift.org/openshift/knative-v0.14.2:knative-eventing-channel-dispatcher
           - name: IMAGE_KN_CLI_ARTIFACTS
             image: registry.svc.ci.openshift.org/openshift/knative-v0.13.2:kn-cli-artifacts
         version: 1.8.0


### PR DESCRIPTION
This patch updates catalogsource by:

```
$ cd openshift/olm/ && bash catalog.sh
```

to use Kourier image `proxyv2-ubi8:1.1.0` as the serverless-operator updates the Kourier manifest by https://github.com/openshift-knative/serverless-operator/commit/467bf238c54816cd12cd85f96a4b7152d64aa299.

https://github.com/openshift/knative-serving/pull/494 proved the error in https://github.com/openshift/knative-serving/pull/481#issuecomment-647303279 fixed.

The test still failed but it is only 
- TestRequestLogs
- ~TestRevisionTimeout/when_scaling_up_from_0_and_it_does_exceed_timeout_seconds~
- TestServiceWithTrafficSplit

The TestServiceWithTrafficSplit is flake and other two will be fixed by another PR.