### PR TITLE
[WIP - debug only] dump webhook on OpenShift prow env

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,6 +7,15 @@ set -x
 
 env
 
+echo "mutatingwebhookconfigurations"
+oc get mutatingwebhookconfigurations  --all-namespaces  -o yaml
+echo ""
+
+echo "validatingwebhookconfigurations"
+oc get validatingwebhookconfigurations  --all-namespaces  -o yaml
+
+exit 1
+
 scale_up_workers || exit $?
 
 failed=0
@@ -14,7 +23,6 @@ failed=0
 (( !failed )) && install_knative || failed=1
 (( !failed )) && prepare_knative_serving_tests || failed=2
 (( !failed )) && run_e2e_tests || failed=3
-(( failed )) && dump_cluster_state
 (( failed )) && exit $failed
 
 success


### PR DESCRIPTION
I guess OCP 4.6 and 4.5 have a difference. Especially 4.6 has a webhook which has `sideEffect: Unknown` webhook.

/cc