### PR TITLE
[WIP] Collect log by must-gather instead of upstream's dump

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -261,3 +261,13 @@ function run_e2e_tests(){
 
   return $failed
 }
+
+function gather_knative_state {
+  logger.info 'Gather knative state'
+  local gather_dir="${ARTIFACT_DIR:-/tmp}/gather-knative"
+  mkdir -p "$gather_dir"
+
+  oc --insecure-skip-tls-verify adm must-gather \
+    --image=quay.io/openshift-knative/must-gather \
+    --dest-dir "$gather_dir" > "${gather_dir}/gather-knative.log"
+}

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -14,7 +14,7 @@ failed=0
 (( !failed )) && install_knative || failed=1
 (( !failed )) && prepare_knative_serving_tests || failed=2
 (( !failed )) && run_e2e_tests || failed=3
-(( failed )) && dump_cluster_state
+(( failed )) && gather_knative_state
 (( failed )) && exit $failed
 
 success


### PR DESCRIPTION
use `must-gather` instead of upstream's`dump_cluster_state`.

This patch is to verify if the change works or not on CI.

/cc