### PR TITLE
Collect Knative specific log by must-gather instead of upstream's dump script

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -261,3 +261,13 @@ function run_e2e_tests(){
 
   return $failed
 }
+
+function gather_knative_state {
+  logger.info 'Gather knative state'
+  local gather_dir="${ARTIFACT_DIR:-/tmp}/gather-knative"
+  mkdir -p "$gather_dir"
+
+  oc --insecure-skip-tls-verify adm must-gather \
+    --image=quay.io/openshift-knative/must-gather \
+    --dest-dir "$gather_dir" > "${gather_dir}/gather-knative.log"
+}

--- a/openshift/e2e-tests-local.sh
+++ b/openshift/e2e-tests-local.sh
@@ -11,7 +11,7 @@ failed=0
 
 (( !failed )) && prepare_knative_serving_tests || failed=1
 (( !failed )) && run_e2e_tests "$TEST" || failed=2
-(( failed )) && dump_cluster_state
+(( failed )) && gather_knative_state
 (( failed )) && exit $failed
 
 success

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -14,7 +14,7 @@ failed=0
 (( !failed )) && install_knative || failed=1
 (( !failed )) && prepare_knative_serving_tests || failed=2
 (( !failed )) && run_e2e_tests || failed=3
-(( failed )) && dump_cluster_state
+(( failed )) && gather_knative_state
 (( failed )) && exit $failed
 
 success


### PR DESCRIPTION
Currently `dump_cluster_state` is called when test failed.
But it is a upstream's util func, which collects duplicaated logs and outputs into the invalid directory for OpenShift prow.

Hence this patch changes to use must-gather.

https://github.com/openshift/knative-serving/pull/514 verified the change. Please see `gather-knative` in [e2e-aws-ocp-46](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_knative-serving/514/pull-ci-openshift-knative-serving-release-next-4.6-e2e-aws-ocp-46/1288340708842803200/artifacts/e2e-aws-ocp-46/).

/cc @markusthoemmes @mgencur 
