### PR TITLE
Enable allow-zero-initial-scale in config-autoscaler

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -209,6 +209,9 @@ function run_e2e_tests(){
   header "Leaders"
   kubectl get lease -n "${SYSTEM_NAMESPACE}"
 
+  # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
+  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}' || fail_test
+
   # Give the controller time to sync with the rest of the system components.
   sleep 30
 

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -41,11 +41,7 @@ function resolve_file() {
   echo "---" >> "$to"
   # 1. Rewrite image references
   # 2. Update config map entry
-  # 3. Remove comment lines
-  # 4. Remove empty lines
   sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
       -e "s+\(.* queueSidecarImage: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
-      -e '/^[ \t]*#/d' \
-      -e '/^[ \t]*$/d' \
       "$file" >> "$to"
 }


### PR DESCRIPTION
This patch enables allow-zero-initial-scale in config-autoscaler

Also, stop removing comments and whiteline in `knative-serving-ci.yaml`.
Because the configmap's [checksum](https://github.com/openshift/knative-serving/blob/release-next/openshift/release/knative-serving-ci.yaml#L978) is invalid so serverless-operator gets error when it enabled `allow-zero-initial-scale`.

/cc @markusthoemmes @mgencur 
