### PR TITLE
[SRVKS-609] Disable all metric recording.

### DIFF
--- a/vendor/knative.dev/pkg/metrics/config.go
+++ b/vendor/knative.dev/pkg/metrics/config.go
@@ -153,10 +153,7 @@ func NewStackdriverClientConfigFromMap(config map[string]string) *StackdriverCli
 // record applies the `ros` Options to each measurement in `mss` and then records the resulting
 // measurements in the metricsConfig's designated backend.
 func (mc *metricsConfig) record(ctx context.Context, mss []stats.Measurement, ros ...stats.Options) error {
-	if mc == nil || mc.recorder == nil {
-		return stats.RecordWithOptions(ctx, append(ros, stats.WithMeasurements(mss...))...)
-	}
-	return mc.recorder(ctx, mss, ros...)
+	return nil
 }
 
 func createMetricsConfig(ops ExporterOptions, logger *zap.SugaredLogger) (*metricsConfig, error) {


### PR DESCRIPTION
We're disabling all metric endpoints currently anyway and 609 shows that the current way of doing metric collection is problematic.

As a result, we should just disable all metric recording for now until we actually want to make use of the metrics.