### PR TITLE
Update Kourier gateway and controller addresses

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -109,6 +109,10 @@ function install_knative(){
   KOURIER_CONTROL=$(grep -w "gcr.io/knative-nightly/knative.dev/net-kourier/cmd/kourier" third_party/kourier-latest/kourier.yaml  | awk '{print $NF}')
   KOURIER_GATEWAY=$(grep -w "docker.io/maistra/proxyv2-ubi8" third_party/kourier-latest/kourier.yaml  | awk '{print $NF}')
 
+  # Add these variable manually until operator implements it. See SRVKS-610
+  sed -i -e 's/value: "kourier-system"/value: "knative-serving-ingress"/g'  third_party/kourier-latest/kourier.yaml
+  sed -i -e 's/kourier-control.knative-serving/kourier-control.knative-serving-ingress/g'  third_party/kourier-latest/kourier.yaml
+
   sed -i -e "s|docker.io/maistra/proxyv2-ubi8:.*|${KOURIER_GATEWAY}|g"                                         ${CATALOG_SOURCE}
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:kourier|${KOURIER_CONTROL}|g"               ${CATALOG_SOURCE}
 


### PR DESCRIPTION
Since https://github.com/knative-sandbox/net-kourier/commit/ce84020add98cb9a051eee9df062d6711e1d64e7, upstream Kourier deploys the controller on `knative-serving` namespace. While, downstream deploys Kourier controller and gateway in  `knative-serving-ingress` namespace.

Hence this patch updates the value of `KOURIER_GATEWAY_NAMESPACE` and `socket_address`.

/cc @mgencur  