### PR TITLE
Find yaml files recursively

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -13,4 +13,4 @@ else
     tag=$release
 fi
 
-resolve_resources config/ "$output_file" "$image_prefix" "$tag"
+resolve_resources config/core/ "$output_file" "$image_prefix" "$tag"

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -12,7 +12,7 @@ function resolve_resources(){
 
   > "$resolved_file_name"
 
-  for yaml in "$dir"/*.yaml; do
+  for yaml in `find $dir -name "*.yaml"`; do
     resolve_file "$yaml" "$resolved_file_name" "$image_prefix" "$image_tag"
   done
 }


### PR DESCRIPTION
Since https://github.com/knative/serving/commit/9d33e54858bbab1109b91ec6567e60778cb8d4c1, `serving/config` does not have symlink but yaml files are stored in `config/core`.

Hence this patch changes the script to find yaml files by `find` command recursively.

/cc @mgencur @markusthoemmes 