### PR TITLE
Sort manifests to create Image CRD first

### DIFF
--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -12,7 +12,7 @@ function resolve_resources(){
 
   > "$resolved_file_name"
 
-  for yaml in `find $dir -name "*.yaml"`; do
+  for yaml in `find $dir -name "*.yaml" | sort`; do
     resolve_file "$yaml" "$resolved_file_name" "$image_prefix" "$image_tag"
   done
 }


### PR DESCRIPTION
Today, knative-operator fails with [the error](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_knative-serving/534/pull-ci-openshift-knative-serving-release-next-4.6-e2e-aws-ocp-46/1301140931499528192/artifacts/e2e-aws-ocp-46/gather-knative/quay-io-openshift-knative-must-gather-sha256-51049ace7b41db7499a225b27bf11492e419245a3c49581020c184d6c816d410/openshift-operators/pods/knative-operator-676647b664-k9z9z.log)

```
failed to apply non rbac manifest: no matches for kind \"Image\" in version \"caching.internal.knative.dev/v1alpha1\""
```

This is because operator tries to apply Image before image's CRD.

https://github.com/openshift/knative-serving/blob/release-next/openshift/release/knative-serving-ci.yaml#L743

To fix it, this patch adds `sort` command to generate knative-serving-ci.yaml.

/cc @markusthoemmes @mgencur 