### PR TITLE
Print indexes of invalid responses in conformance tests

### DIFF
--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -130,7 +130,7 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 	//   WHERE body IN $expectedResponses
 	//   GROUP BY body
 	// )
-	for _, ar := range actualResponses {
+	for i, ar := range actualResponses {
 		expected := false
 		for _, er := range expectedResponses {
 			if strings.Contains(ar, er) {
@@ -140,9 +140,13 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 		}
 		if !expected {
 			badCounts[ar]++
+			t.Logf("For domain %s: got unexpected response for request %d", domain, i)
 		}
 	}
-
+	// Print unexpected responses for debugging purposes
+	for badResponse, count := range badCounts {
+		t.Logf("For domain %s: saw unexpected response %q %d times.", domain, badResponse, count)
+	}
 	// Verify that we saw each entry in "expectedResponses" at least "min" times.
 	// check(SELECT body FROM $counts WHERE total < $min)
 	totalMatches := 0
@@ -151,14 +155,10 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 		if count < min {
 			return fmt.Errorf("domain %s failed: want at least %d, got %d for response %q", domain, min, count, er)
 		}
-
 		t.Logf("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
 		totalMatches += count
 	}
 	// Verify that the total expected responses match the number of requests made.
-	for badResponse, count := range badCounts {
-		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
-	}
 	if totalMatches < num {
 		return fmt.Errorf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num)
 	}

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -130,7 +130,7 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 	//   WHERE body IN $expectedResponses
 	//   GROUP BY body
 	// )
-	for _, ar := range actualResponses {
+	for i, ar := range actualResponses {
 		expected := false
 		for _, er := range expectedResponses {
 			if strings.Contains(ar, er) {
@@ -140,9 +140,13 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 		}
 		if !expected {
 			badCounts[ar]++
+			t.Logf("For domain %s: got unexpected response for request %d", domain, i)
 		}
 	}
-
+	// Print unexpected responses for debugging purposes
+	for badResponse, count := range badCounts {
+		t.Logf("For domain %s: saw unexpected response %q %d times.", domain, badResponse, count)
+	}
 	// Verify that we saw each entry in "expectedResponses" at least "min" times.
 	// check(SELECT body FROM $counts WHERE total < $min)
 	totalMatches := 0
@@ -151,14 +155,10 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 		if count < min {
 			return fmt.Errorf("domain %s failed: want at least %d, got %d for response %q", domain, min, count, er)
 		}
-
 		t.Logf("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
 		totalMatches += count
 	}
 	// Verify that the total expected responses match the number of requests made.
-	for badResponse, count := range badCounts {
-		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
-	}
 	if totalMatches < num {
 		return fmt.Errorf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num)
 	}

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -130,7 +130,7 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 	//   WHERE body IN $expectedResponses
 	//   GROUP BY body
 	// )
-	for _, ar := range actualResponses {
+	for i, ar := range actualResponses {
 		expected := false
 		for _, er := range expectedResponses {
 			if strings.Contains(ar, er) {
@@ -140,9 +140,13 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 		}
 		if !expected {
 			badCounts[ar]++
+			t.Logf("For domain %s: got unexpected response for request %d", domain, i)
 		}
 	}
-
+	// Print unexpected responses for debugging purposes
+	for badResponse, count := range badCounts {
+		t.Logf("For domain %s: saw unexpected response %q %d times.", domain, badResponse, count)
+	}
 	// Verify that we saw each entry in "expectedResponses" at least "min" times.
 	// check(SELECT body FROM $counts WHERE total < $min)
 	totalMatches := 0
@@ -151,14 +155,10 @@ func checkResponses(t pkgTest.TLegacy, num int, min int, domain string, expected
 		if count < min {
 			return fmt.Errorf("domain %s failed: want at least %d, got %d for response %q", domain, min, count, er)
 		}
-
 		t.Logf("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
 		totalMatches += count
 	}
 	// Verify that the total expected responses match the number of requests made.
-	for badResponse, count := range badCounts {
-		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
-	}
 	if totalMatches < num {
 		return fmt.Errorf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num)
 	}


### PR DESCRIPTION
* also move printing bad responses to the right place (upstream master
does the same now)

Additional debug information for future analysis of https://issues.redhat.com/browse/SRVKS-616