### PR TITLE
Fix and minimize gRPC patch

### DIFF
--- a/openshift/patches/004-grpc.patch
+++ b/openshift/patches/004-grpc.patch
@@ -1,29 +1,13 @@
 diff --git a/test/e2e/grpc_test.go b/test/e2e/grpc_test.go
-index 0c1ca6ad3..eada6baa3 100644
+index c7814cb54..0a7a4c636 100644
 --- a/test/e2e/grpc_test.go
 +++ b/test/e2e/grpc_test.go
-@@ -316,6 +316,7 @@ func streamTest(tc *testContext, host, domain string) {
- func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
- 	t.Helper()
- 	t.Parallel()
-+	resolvable := false
- 
- 	// Setup
- 	clients := Setup(t)
-@@ -343,14 +344,14 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
- 		url,
- 		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
- 		"gRPCPingReadyToServe",
--		test.ServingFlags.ResolvableDomain,
-+		resolvable,
- 		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.Https),
- 	); err != nil {
- 		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
+@@ -350,7 +350,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
  	}
  
  	host := url.Host
 -	if !test.ServingFlags.ResolvableDomain {
-+	if !resolvable {
++	if true {
  		addr, mapper, err := ingress.GetIngressEndpoint(context.Background(), clients.KubeClient.Kube, pkgTest.Flags.IngressEndpoint)
  		if err != nil {
  			t.Fatal("Could not get service endpoint:", err)


### PR DESCRIPTION
Again, gRPC patch is conflicted with upstream's https://github.com/knative/serving/commit/c3438a4a163650f28a37ef93871717f594b2ceb0

This patch fixes the confliction and minimize the patch to avoid these
confliction as much as possible.

/cc @markusthoemmes @mgencur 