### PR TITLE
Update 003-routeretry.patch to drop v1alpha1 and v1beta1

### DIFF
--- a/openshift/patches/003-routeretry.patch
+++ b/openshift/patches/003-routeretry.patch
@@ -1,5 +1,5 @@
 diff --git a/test/v1/route.go b/test/v1/route.go
-index 3419f1d77..faaebd4b5 100644
+index a9530c129..b1e62298f 100644
 --- a/test/v1/route.go
 +++ b/test/v1/route.go
 @@ -19,6 +19,7 @@ package v1
@@ -10,74 +10,7 @@ index 3419f1d77..faaebd4b5 100644
  
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/apimachinery/pkg/util/wait"
-@@ -114,8 +115,20 @@ func IsRouteNotReady(r *v1.Route) (bool, error) {
- }
- 
- // RetryingRouteInconsistency retries common requests seen when creating a new route
-+// - 404 until the route is propagated to the proxy
-+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
- func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
-+	const neededSuccesses = 5
-+	var successes int
- 	return func(resp *spoof.Response) (bool, error) {
-+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
-+			successes = 0
-+			return false, nil
-+		}
-+		successes++
-+		if successes < neededSuccesses {
-+			return false, nil
-+		}
- 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
- 		return innerCheck(resp)
- 	}
-diff --git a/test/v1alpha1/route.go b/test/v1alpha1/route.go
-index 87406b63e..dbbe4840e 100644
---- a/test/v1alpha1/route.go
-+++ b/test/v1alpha1/route.go
-@@ -21,6 +21,7 @@ package v1alpha1
- import (
- 	"context"
- 	"fmt"
-+	"net/http"
- 
- 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
- 	"k8s.io/apimachinery/pkg/util/wait"
-@@ -50,9 +51,20 @@ func CreateRoute(t pkgTest.T, clients *test.Clients, names test.ResourceNames, f
- }
- 
- // RetryingRouteInconsistency retries common requests seen when creating a new route
--// TODO(5573): Remove this.
-+// - 404 until the route is propagated to the proxy
-+// - 503 to account for Openshift route inconsistency (https://jira.coreos.com/browse/SRVKS-157)
- func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.ResponseChecker {
-+	const neededSuccesses = 5
-+	var successes int
- 	return func(resp *spoof.Response) (bool, error) {
-+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusServiceUnavailable {
-+			successes = 0
-+			return false, nil
-+		}
-+		successes++
-+		if successes < neededSuccesses {
-+			return false, nil
-+		}
- 		// If we didn't match any retryable codes, invoke the ResponseChecker that we wrapped.
- 		return innerCheck(resp)
- 	}
-diff --git a/test/v1beta1/route.go b/test/v1beta1/route.go
-index 119b4a818..edc2b908d 100644
---- a/test/v1beta1/route.go
-+++ b/test/v1beta1/route.go
-@@ -19,6 +19,7 @@ package v1beta1
- import (
- 	"context"
- 	"fmt"
-+	"net/http"
- 
- 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
- 	"k8s.io/apimachinery/pkg/util/wait"
-@@ -116,8 +117,20 @@ func IsRouteNotReady(r *v1beta1.Route) (bool, error) {
+@@ -125,8 +126,20 @@ func IsRouteFailed(r *v1.Route) (bool, error) {
  }
  
  // RetryingRouteInconsistency retries common requests seen when creating a new route


### PR DESCRIPTION
https://github.com/knative/serving/commit/13e6833194913381e3ab2231175f800bfc0380db and https://github.com/knative/serving/commit/862d230322e0e33e94e7c3a04d6f8fd67ad81a03 removed `test/{v1alpha1,v1beta1}`.

Hence this patch updates 003-routeretry.patch to drop them.

/cc @markusthoemmes @mgencur 