### PR TITLE
[RELEASE-v0.17.3] Reconcile Ingress when label was different from desired

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -54,16 +54,19 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, r *v1.Route, desired 
 	} else if err != nil {
 		return nil, err
 	} else if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) ||
-		!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) {
+		!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) ||
+		!equality.Semantic.DeepEqual(ingress.Labels, desired.Labels) {
 		// It is notable that one reason for differences here may be defaulting.
 		// When that is the case, the Update will end up being a nop because the
 		// webhook will bring them into alignment and no new reconciliation will occur.
-		// Also, compare annotation in case ingress.Class is updated.
+		// Also, compare annotation and label in case ingress.Class or parent route's labels
+		// is updated.
 
 		// Don't modify the informers copy
 		origin := ingress.DeepCopy()
 		origin.Spec = desired.Spec
 		origin.Annotations = desired.Annotations
+		origin.Labels = desired.Labels
 		updated, err := c.netclient.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(origin)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update Ingress: %w", err)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -582,7 +582,7 @@ func TestReconcile(t *testing.T) {
 			{
 				Object: simpleReadyIngress(
 					Route("default", "different-domain", WithConfigTarget("config"),
-						WithAnotherDomain, WithRouteGeneration(1)),
+						WithAnotherDomain, WithRouteGeneration(1), WithRouteLabel(map[string]string{"app": "prod"})),
 					&traffic.Config{
 						Targets: map[string]traffic.RevisionTargets{
 							traffic.DefaultTarget: {{
@@ -808,8 +808,7 @@ func TestReconcile(t *testing.T) {
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngress(
 				Route("default", "becomes-public", WithConfigTarget("config"),
-					WithRouteUID("65-23"), WithRouteGeneration(1), WithRouteObservedGeneration,
-					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
+					WithRouteUID("65-23"), WithRouteGeneration(1), WithRouteObservedGeneration),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{


### PR DESCRIPTION
As per subject, this patch changes to reconcile Ingress when
it was different from desired.

This patch is a cherry-pick for 6f5e1cc against 0.17.3 branch.

/cc @markusthoemmes 