### PR TITLE
Use the serverless-operator v1.10.0 to do our testing for now

### DIFF
--- a/openshift/olm/config_map.patch
+++ b/openshift/olm/config_map.patch
@@ -53,7 +53,7 @@ index 21f7bc46b..62b0e28c8 100644
 +                        volumeMounts:
 +                        - mountPath: /tmp/kourier
 +                          name: kourier-manifest
-                         image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                         image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
                          command:
                          - knative-openshift
 @@ -679,7 +709,7 @@ data:

--- a/openshift/olm/knative-serving.catalogsource.yaml
+++ b/openshift/olm/knative-serving.catalogsource.yaml
@@ -659,7 +659,7 @@ data:
                     serviceAccountName: knative-operator
                     containers:
                       - name: knative-openshift
-                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
                         command:
                         - knative-openshift
                         imagePullPolicy: Always
@@ -748,7 +748,7 @@ data:
                     serviceAccountName: knative-openshift-ingress
                     containers:
                       - name: knative-openshift-ingress
-                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+                        image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
                         commangd:
                         - knative-openshift-ingress
                         imagePullPolicy: Always
@@ -861,9 +861,9 @@ data:
           - name: knative-operator
             image: registry.svc.ci.openshift.org/openshift/knative-v0.15.1:knative-operator
           - name: knative-openshift
-            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-operator
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-operator
           - name: knative-openshift-ingress
-            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-nightly:knative-openshift-ingress
+            image: registry.svc.ci.openshift.org/openshift/openshift-serverless-v1.10.0:knative-openshift-ingress
           - name: IMAGE_eventing-controller__eventing-controller
             image: registry.svc.ci.openshift.org/openshift/knative-v0.15.2:knative-eventing-controller
           - name: IMAGE_eventing-webhook__eventing-webhook


### PR DESCRIPTION
This is somewhat of a stopgap solution to continue to be able to productise Knative Serving backports. This should ultimately use v1.11.0 but I want to avoid `nightly` as that'll change over time.