### PR TITLE
Install yq and httpd-tools in base image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -5,7 +5,9 @@ FROM openshift/origin-release:golang-1.14
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
-RUN yum install -y kubectl ansible
+RUN yum install -y kubectl ansible httpd-tools
+
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Installation of serverless-operator with the new bundle format would like to use these tools.
This patch changes base image to install them.

/cc @markusthoemmes @mgencur 