### PR TITLE
Fix gRPC patch

### DIFF
--- a/openshift/patches/004-grpc.patch
+++ b/openshift/patches/004-grpc.patch
@@ -1,5 +1,5 @@
 diff --git a/test/e2e/grpc_test.go b/test/e2e/grpc_test.go
-index c7814cb54..0a7a4c636 100644
+index 2ee2b76ab..59e37500a 100644
 --- a/test/e2e/grpc_test.go
 +++ b/test/e2e/grpc_test.go
 @@ -350,7 +350,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
@@ -8,6 +8,6 @@ index c7814cb54..0a7a4c636 100644
  	host := url.Host
 -	if !test.ServingFlags.ResolvableDomain {
 +	if true {
- 		addr, mapper, err := ingress.GetIngressEndpoint(context.Background(), clients.KubeClient.Kube, pkgTest.Flags.IngressEndpoint)
+ 		addr, mapper, err := ingress.GetIngressEndpoint(context.Background(), clients.KubeClient, pkgTest.Flags.IngressEndpoint)
  		if err != nil {
  			t.Fatal("Could not get service endpoint:", err)


### PR DESCRIPTION
Since this commit https://github.com/knative/serving/commit/f23b78989a1cea8cfd1933d12369190ef7bf2b33, gRPC was failing as:

```
+ git apply openshift/patches/001-object.patch openshift/patches/003-routeretry.patch openshift/patches/004-grpc.patch openshift/patches/005-dryrun.patch
error: patch failed: test/e2e/grpc_test.go:350
error: test/e2e/grpc_test.go: patch does not apply
```

This patch fixes the patch file.

/cc @markusthoemmes @mgencur 