### PR TITLE
Fix 003-routeretry.patch

### DIFF
--- a/openshift/patches/003-routeretry.patch
+++ b/openshift/patches/003-routeretry.patch
@@ -1,5 +1,5 @@
 diff --git a/test/v1/route.go b/test/v1/route.go
-index a9530c129..b1e62298f 100644
+index 170a7b2a9..c794fd586 100644
 --- a/test/v1/route.go
 +++ b/test/v1/route.go
 @@ -19,6 +19,7 @@ package v1
@@ -7,9 +7,9 @@ index a9530c129..b1e62298f 100644
  	"context"
  	"fmt"
 +	"net/http"
+ 	"testing"
  
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
- 	"k8s.io/apimachinery/pkg/util/wait"
 @@ -125,8 +126,20 @@ func IsRouteFailed(r *v1.Route) (bool, error) {
  }
  


### PR DESCRIPTION
This patch fixes 003-routeretry.patch.

It started conflicting last night:

```
+ git apply openshift/patches/001-object.patch openshift/patches/003-routeretry.patch openshift/patches/004-grpc.patch openshift/patches/005-dryrun.patch
error: patch failed: test/v1/route.go:19
error: test/v1/route.go: patch does not apply
```

/cc @markusthoemmes @mgencur 