### PR TITLE
Add Dockerfile to build domain-mapping and domain-mapping-webhook images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/nscert ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./cmd/networking/nscert ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate ./cmd/domain-mapping ./cmd/domain-mapping-webhook
 TEST_IMAGES=$(shell find ./test/test_images ./test/test_images/multicontainer -mindepth 1 -maxdepth 1 -type d)
 DOCKER_REPO_OVERRIDE=
 BRANCH=

--- a/openshift/ci-operator/knative-images/domain-mapping-webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/domain-mapping-webhook/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD domain-mapping-webhook /ko-app/domain-mapping-webhook
+ENTRYPOINT ["/ko-app/domain-mapping-webhook"]

--- a/openshift/ci-operator/knative-images/domain-mapping/Dockerfile
+++ b/openshift/ci-operator/knative-images/domain-mapping/Dockerfile
@@ -1,0 +1,6 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+USER 65532
+
+ADD domain-mapping /ko-app/domain-mapping
+ENTRYPOINT ["/ko-app/domain-mapping"]


### PR DESCRIPTION
This patch adds Dockerfile for domain-mapping and domain-mapping-webhook.

/cc @markusthoemmes @mgencur 