### PR TITLE
[Backport] Fix nil-pointer on accessing condition in autoscaler

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -148,7 +148,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		pa.Status.MarkSKSReady()
 	} else {
 		logger.Debug("SKS is not ready, marking SKS status not ready")
-		pa.Status.MarkSKSNotReady(sks.Status.GetCondition(nv1alpha1.ServerlessServiceConditionReady).Message)
+		pa.Status.MarkSKSNotReady(sks.Status.GetCondition(nv1alpha1.ServerlessServiceConditionReady).GetMessage())
 	}
 
 	logger.Infof("PA scale got=%d, want=%d, desiredPods=%d ebc=%d", ready, want,
@@ -242,7 +242,7 @@ func computeActiveCondition(ctx context.Context, pa *pav1alpha1.PodAutoscaler, p
 	// In pre-0.17 we could have scaled down normally without ever setting ScaleTargetInitialized.
 	// In this case we'll be in the NoTraffic/inactive state.
 	// TODO(taragu): remove after 0.19
-	alreadyScaledDownSuccessfully := minReady > 0 && pa.Status.GetCondition(pav1alpha1.PodAutoscalerConditionActive).Reason == noTrafficReason
+	alreadyScaledDownSuccessfully := minReady > 0 && pa.Status.GetCondition(pav1alpha1.PodAutoscalerConditionActive).GetReason() == noTrafficReason
 	if (pc.ready >= minReady || alreadyScaledDownSuccessfully) && pa.Status.ServiceName != "" {
 		pa.Status.MarkScaleTargetInitialized()
 	}


### PR DESCRIPTION
Backport of https://github.com/knative/serving/pull/9794. I am wondering since there are direct calls to the struct fields elsewhere if we are going to hit this in other areas of the code base in the future. For example [here](https://github.com/openshift/knative-serving/blob/be939c54b845f1577b97a1e9512d771b06b6f93e/pkg/apis/serving/v1/revision_lifecycle.go#L190). 