### PR TITLE
Do not apply test/config/config-deployment.yaml directly

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -206,6 +206,8 @@ metadata:
   namespace: ${SERVING_NAMESPACE}
 spec:
   config:
+    deployment:
+      progressDeadline: "120s"
     observability:
       logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}",
         "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}",
@@ -242,6 +244,9 @@ function create_configmaps(){
 
 function prepare_knative_serving_tests_nightly {
   echo ">> Creating test resources for OpenShift (test/config/)"
+
+  # workaround until https://github.com/knative/operator/issues/431 was fixed.
+  rm -f test/config/config-deployment.yaml
 
   oc apply -f test/config
 

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -287,6 +287,8 @@ function run_e2e_tests(){
     -run "^(${test_name})$" \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --enable-alpha \
+    --enable-beta \
     --resolvabledomain "$(ingress_class)" || failed=$?
 
     return $failed
@@ -304,6 +306,8 @@ function run_e2e_tests(){
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --enable-alpha \
+    --enable-beta \
     --resolvabledomain "$(ingress_class)" || failed=1
 
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"tag-header-based-routing": "enabled"}}}}' || fail_test

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -13,4 +13,4 @@ else
     tag=$release
 fi
 
-resolve_resources "config/core/ config/hpa-autoscaling/" "$output_file" "$image_prefix" "$tag"
+resolve_resources "config/core/ config/hpa-autoscaling/ config/domain-mapping/" "$output_file" "$image_prefix" "$tag"


### PR DESCRIPTION
Upstream started setting `queueSidecarImage` and `progressDeadline` in `test/config/config-deployment.yaml` by https://github.com/knative/serving/commit/a39fbc0e2e75f7a7dd5129d98a23f09fd9f0d04c.
The `queueSidecarImage` should be reconciled by operator but there is [an issue](https://github.com/knative/operator/issues/431) which does not reconcile configmap soon when it was modified.

Hence this patch stops applying `test/config/config-deployment.yaml` but configures `progressDeadline` in `knativeserving` CR.

Also this patch enables alpha and beta tests.

/cc @markusthoemmes @mgencur  
