### PR TITLE
Use domain-mapping image built by CI

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -102,6 +102,8 @@ function update_csv(){
   sed -i -e "s|\"registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-autoscaler-hpa\"|\"${IMAGE_FORMAT//\$\{component\}/knative-serving-autoscaler-hpa}\"|g" ${CSV}
   sed -i -e "s|\"registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-controller\"|\"${IMAGE_FORMAT//\$\{component\}/knative-serving-controller}\"|g"         ${CSV}
   sed -i -e "s|\"registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-webhook\"|\"${IMAGE_FORMAT//\$\{component\}/knative-serving-webhook}\"|g"               ${CSV}
+  sed -i -e "s|\"registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-domain-mapping\"|\"${IMAGE_FORMAT//\$\{component\}/knative-serving-domain-mapping}\"|g"                       ${CSV}
+  sed -i -e "s|\"registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-domain-mapping-webhook\"|\"${IMAGE_FORMAT//\$\{component\}/knative-serving-domain-mapping-webhook}\"|g"       ${CSV}
   sed -i -e "s|\"registry.svc.ci.openshift.org/openshift/knative-.*:knative-serving-storage-version-migration\"|\"${IMAGE_FORMAT//\$\{component\}/knative-serving-storage-version-migration}\"|g" ${CSV}
 
   # Replace kourier's image with the latest ones from third_party/kourier-latest


### PR DESCRIPTION
Current CI is [failing only on OCP 4.7](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_knative-serving/633/pull-ci-openshift-knative-serving-release-next-4.7-e2e-aws-ocp-47/1351681317162455040).
This is because domain-mapping uses 0.19 image which does not include knative@be44108.

Hence this patch updates script to use correct domain-mapping images.

/cc @markusthoemmes @mgencur 