### PR TITLE
Use golang 1.15

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.14
+FROM openshift/origin-release:golang-1.15
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
This is not mandatory requirement but it's been a while since 1.15 was available
in test platform so it bumps golang to 1.15.

/cc @markusthoemmes @mgencur @rhuss