### PR TITLE
Fix race condition with Prober logger in upgrade tests

### DIFF
--- a/test/upgrade/probe.go
+++ b/test/upgrade/probe.go
@@ -51,7 +51,7 @@ func ProbeTest() pkgupgrade.BackgroundOperation {
 			// This polls until we get a 200 with the right body.
 			assertServiceResourcesUpdated(c.T, clients, *names, url, test.PizzaPlanetText1)
 
-			prober = test.RunRouteProber(c.T.Logf, clients, url, test.AddRootCAtoTransport(context.Background(), c.T.Logf, clients, test.ServingFlags.HTTPS))
+			prober = test.RunRouteProber(c.Log.Infof, clients, url, test.AddRootCAtoTransport(context.Background(), c.T.Logf, clients, test.ServingFlags.HTTPS))
 		},
 		func(c pkgupgrade.Context) {
 			// Verify


### PR DESCRIPTION
Fixes https://github.com/knative/pkg/issues/2026

The actual issue is that the test context expires between individual
stages run by the upgrade framework. This fix passes an external logger
that survives the stages.

Upstream PR: https://github.com/knative/serving/pull/10815