### PR TITLE
Make the scripts use main instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ fixes needed only for the OpenShift side of things.
 
 ## How this repository works ?
 
-The `master` branch holds up-to-date specific [openshift files](./openshift) 
+The default branch holds up-to-date specific [openshift files](./openshift) 
 that are necessary for CI setups and maintaining it. This includes:
 
 - Scripts to create a new release branch from `upstream`
@@ -57,7 +57,7 @@ Once the file is generated, it must be committed to the
 [openshift/release](https://github.com/openshift/release) repository, as the other manifests linked above. The
 naming schema is `openshift-knative-serving-BRANCH.yaml`, thus the
 files existing already correspond to our existing releases and the
-master branch itself.
+default branch itself.
 
 After the file has been added to the folder as mentioned above, the
 job manifests itself will need to be generated as is described in the

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -15,9 +15,9 @@ fi
 git fetch upstream --tags
 git checkout -b "$target" "$release"
 
-# Update openshift's master and take all needed files from there.
-git fetch openshift master
-git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
+# Update openshift's main and take all needed files from there.
+git fetch openshift main
+git checkout openshift/main -- openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make RELEASE=$release generate-release
 make RELEASE=ci generate-release

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -10,9 +10,9 @@ REPO_NAME=`basename $(git rev-parse --show-toplevel)`
 git fetch upstream master
 git checkout upstream/master -B release-next
 
-# Update openshift's master and take all needed files from there.
-git fetch openshift master
-git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
+# Update openshift's main and take all needed files from there.
+git fetch openshift main
+git checkout openshift/main openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile


### PR DESCRIPTION
As per title, these are the adjustments necessary to be able to switch to `main` as the default branch of this repo.