### PR TITLE
Assorted cherry-picks to fix activator bug and improve cold-start latency

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -31,7 +31,6 @@ import (
 	network "knative.dev/networking/pkg"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/health"
-	"knative.dev/serving/pkg/queue/readiness"
 )
 
 const (
@@ -74,10 +73,6 @@ func standaloneProbeMain(timeout time.Duration, transport http.RoundTripper) (ex
 	if queueServingPort == 0 {
 		fmt.Fprintln(os.Stderr, "port must be a positive value, got 0")
 		return 1
-	}
-
-	if timeout == 0 {
-		timeout = readiness.PollTimeout
 	}
 
 	if err := probeQueueHealthPath(timeout, int(queueServingPort), transport); err != nil {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -62,7 +62,7 @@ const (
 )
 
 var (
-	readinessProbeTimeout = flag.Duration("probe-period", -1, "run readiness probe with given timeout")
+	startupProbeTimeout = flag.Duration("probe-period", -1, "run startup probe with given timeout")
 
 	// This creates an abstract socket instead of an actual file.
 	unixSocketPath = "@/knative.dev/serving/queue.sock"
@@ -109,7 +109,7 @@ func main() {
 	flag.Parse()
 
 	// If this is set, we run as a standalone binary to probe the queue-proxy.
-	if *readinessProbeTimeout >= 0 {
+	if *startupProbeTimeout >= 0 {
 		// Use a unix socket rather than TCP to avoid going via entire TCP stack
 		// when we're actually in the same container.
 		transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -117,7 +117,7 @@ func main() {
 			return net.Dial("unix", unixSocketPath)
 		}
 
-		os.Exit(standaloneProbeMain(*readinessProbeTimeout, transport))
+		os.Exit(standaloneProbeMain(*startupProbeTimeout, transport))
 	}
 
 	// Otherwise, we run as the queue-proxy service.

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	network "knative.dev/networking/pkg"
@@ -47,6 +48,7 @@ const reportInterval = time.Second
 type revisionStats struct {
 	stats        *network.RequestStats
 	firstRequest float64
+	refs         atomic.Int64
 }
 
 // ConcurrencyReporter reports stats based on incoming requests and ticks.
@@ -80,6 +82,7 @@ func NewConcurrencyReporter(ctx context.Context, podName string, statCh chan []a
 // handleEvent handles request events (in, out) and updates the respective stats.
 func (cr *ConcurrencyReporter) handleEvent(event network.ReqEvent) {
 	stat, msg := cr.getOrCreateStat(event)
+	defer stat.refs.Dec()
 	if msg != nil {
 		cr.statCh <- []asmetrics.StatMessage{*msg}
 	}
@@ -90,14 +93,16 @@ func (cr *ConcurrencyReporter) handleEvent(event network.ReqEvent) {
 // If absent it creates a new one and returns it, potentially returning a StatMessage too
 // to trigger an immediate scale-from-0.
 func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*revisionStats, *asmetrics.StatMessage) {
-	stat := func() *revisionStats {
-		cr.mux.RLock()
-		defer cr.mux.RUnlock()
-		return cr.stats[event.Key]
-	}()
+	cr.mux.RLock()
+	stat := cr.stats[event.Key]
 	if stat != nil {
+		// Since this is incremented under the lock, it's guaranteed to be observed by
+		// the deletion routine.
+		stat.refs.Inc()
+		cr.mux.RUnlock()
 		return stat, nil
 	}
+	cr.mux.RUnlock()
 
 	// Doubly checked locking.
 	cr.mux.Lock()
@@ -105,6 +110,9 @@ func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*revisio
 
 	stat = cr.stats[event.Key]
 	if stat != nil {
+		// Since this is incremented under the lock, it's guaranteed to be observed by
+		// the deletion routine.
+		stat.refs.Inc()
 		return stat, nil
 	}
 
@@ -112,6 +120,7 @@ func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*revisio
 		stats:        network.NewRequestStats(event.Time),
 		firstRequest: 1,
 	}
+	stat.refs.Inc()
 	cr.stats[event.Key] = stat
 
 	return stat, &asmetrics.StatMessage{
@@ -137,7 +146,11 @@ func (cr *ConcurrencyReporter) report(now time.Time) []asmetrics.StatMessage {
 		cr.mux.Lock()
 		defer cr.mux.Unlock()
 		for _, key := range toDelete {
-			delete(cr.stats, key)
+			// Avoid deleting the stat if a request raced fetching it while we've been
+			// busy reporting.
+			if cr.stats[key].refs.Load() == 0 {
+				delete(cr.stats, key)
+			}
 		}
 	}
 

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -461,6 +461,73 @@ func TestConcurrencyReporterHandler(t *testing.T) {
 	}
 }
 
+func TestConcurrencyReporterRace(t *testing.T) {
+	cr, _, cancel := newTestReporter(t)
+	defer cancel()
+
+	base := time.Now()
+
+	// 1. Request in: Creates the stat (first part of handleEvent)
+	eventIn := network.ReqEvent{
+		Time: base,
+		Type: network.ReqIn,
+		Key:  rev1,
+	}
+	stats, _ := cr.getOrCreateStat(eventIn)
+
+	// 2. Report (will remove the stat immediately)
+	cr.report(base.Add(1 * time.Second))
+
+	// 3. HandleEvent (second part of handleEvent)
+	stats.stats.HandleEvent(eventIn)
+
+	// 4. Request out: Creates a new stat, now negative
+	cr.handleEvent(network.ReqEvent{
+		Time: base.Add(2 * time.Second),
+		Type: network.ReqOut,
+		Key:  rev1,
+	})
+
+	// 5. A negative report (if buggy)
+	got := cr.report(base.Add(2 * time.Second))
+	want := []asmetrics.StatMessage{{
+		Key: rev1,
+		Stat: asmetrics.Stat{
+			AverageConcurrentRequests: 1,
+			RequestCount:              1,
+			PodName:                   activatorPodName,
+		},
+	}}
+	if !cmp.Equal(got, want) {
+		t.Error("Unexpected stats (-want +got):", cmp.Diff(want, got))
+	}
+
+	// 6. It continues to work correctly.
+	cr.handleEvent(network.ReqEvent{
+		Time: base.Add(2500 * time.Millisecond),
+		Type: network.ReqIn,
+		Key:  rev1,
+	})
+	cr.handleEvent(network.ReqEvent{
+		Time: base.Add(3 * time.Second),
+		Type: network.ReqOut,
+		Key:  rev1,
+	})
+
+	got = cr.report(base.Add(3 * time.Second))
+	want = []asmetrics.StatMessage{{
+		Key: rev1,
+		Stat: asmetrics.Stat{
+			AverageConcurrentRequests: 0.5,
+			RequestCount:              1,
+			PodName:                   activatorPodName,
+		},
+	}}
+	if !cmp.Equal(got, want) {
+		t.Error("Unexpected stats (-want +got):", cmp.Diff(want, got))
+	}
+}
+
 func TestMetricsReported(t *testing.T) {
 	reset()
 	cr, ctx, cancel := newTestReporter(t)

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -98,6 +98,7 @@ var (
 					}},
 				},
 			},
+			PeriodSeconds: 1,
 		},
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -77,14 +77,27 @@ var (
 		Name:      QueueContainerName,
 		Resources: createQueueResources(&deploymentConfig, make(map[string]string), &corev1.Container{}),
 		Ports:     append(queueNonServingPorts, queueHTTPPort),
-		ReadinessProbe: &corev1.Probe{
+		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "0"},
+					Command: []string{"/ko-app/queue", "-probe-period", "1h34m38s"},
 				},
 			},
-			PeriodSeconds:  10,
-			TimeoutSeconds: 10,
+			PeriodSeconds:    1,
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+			TimeoutSeconds:   5678,
+		},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+					HTTPHeaders: []corev1.HTTPHeader{{
+						Name:  network.ProbeHeaderName,
+						Value: queue.Name,
+					}},
+				},
+			},
 		},
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -250,8 +250,8 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 
 	// After startup we'll directly use the same http health check endpoint the
 	// execprobe would have used (which will then check the user container).
-	// Unlike the StartupProbe, we don't need to override any of the
-	// timeouts/periods/thresholds here.
+	// Unlike the StartupProbe, we don't need to override any of the other settings
+	// except period here. See below.
 	httpProbe := container.ReadinessProbe.DeepCopy()
 	httpProbe.Handler = corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
@@ -261,6 +261,13 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 				Value: queue.Name,
 			}},
 		},
+	}
+
+	// Default PeriodSeconds to 1 if not set to make for the quickest possible startup
+	// time.
+	// TODO(#10973): Remove this once we're on K8s 1.21
+	if httpProbe.PeriodSeconds == 0 {
+		httpProbe.PeriodSeconds = 1
 	}
 
 	return &corev1.Container{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -171,56 +171,35 @@ func fractionFromPercentage(m map[string]string, k string) (float64, bool) {
 	return value / 100, err == nil
 }
 
-func makeQueueProbe(in *corev1.Probe) *corev1.Probe {
-	if in == nil || in.PeriodSeconds == 0 {
-		out := &corev1.Probe{
-			Handler: corev1.Handler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "0"},
-				},
-			},
-			// The exec probe enables us to retry failed probes quickly to get sub-second
-			// resolution and achieve faster cold-starts.  However, for draining pods as
-			// part of the K8s lifecycle this period will bound the tail of how quickly
-			// we can remove a Pod's endpoint from the K8s service.
-			//
-			// The trade-off here is that exec probes cost CPU to run, and for idle pods
-			// (e.g. due to minScale) we see ~50m/{period} of idle CPU usage in the
-			// queue-proxy.  So while setting this to 1s results in slightly faster drains
-			// it also means that in the steady state the queue-proxy is consuming 10x
-			// more CPU due to probes than with a period of 10s.
-			//
-			// See also: https://github.com/knative/serving/issues/8147
-			PeriodSeconds: 10,
-			// We keep the connection open for a while because we're
-			// actively probing the user-container on that endpoint and
-			// thus don't want to be limited by K8s granularity here.
-			TimeoutSeconds: 10,
-		}
-
-		if in != nil {
-			out.InitialDelaySeconds = in.InitialDelaySeconds
-		}
-		return out
+func makeStartupExecProbe(in *corev1.Probe, progressDeadline time.Duration) *corev1.Probe {
+	if in != nil && in.PeriodSeconds > 0 {
+		// If the user opted-out of the aggressive probing optimisation we don't
+		// need to run a startup probe at all.
+		return nil
 	}
 
-	timeout := time.Second
-	if in.TimeoutSeconds > 1 {
-		timeout = time.Duration(in.TimeoutSeconds) * time.Second
-	}
-
-	return &corev1.Probe{
+	out := &corev1.Probe{
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/ko-app/queue", "-probe-period", timeout.String()},
+				// The exec probe is run as a startup probe so the container will be killed
+				// and restarted if it fails. We use the ProgressDeadline as the timeout
+				// to match the time we'll wait before killing the revision if it
+				// fails to go ready on initial deployment.
+				Command: []string{"/ko-app/queue", "-probe-period", progressDeadline.String()},
 			},
 		},
-		PeriodSeconds:       in.PeriodSeconds,
-		TimeoutSeconds:      int32(timeout.Seconds()),
-		SuccessThreshold:    in.SuccessThreshold,
-		FailureThreshold:    in.FailureThreshold,
-		InitialDelaySeconds: in.InitialDelaySeconds,
+		// The exec probe itself retries aggressively so there's no point retrying via Kubernetes too.
+		TimeoutSeconds:   int32(progressDeadline.Seconds()),
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		PeriodSeconds:    1,
 	}
+
+	if in != nil {
+		out.InitialDelaySeconds = in.InitialDelaySeconds
+	}
+
+	return out
 }
 
 // makeQueueContainer creates the container spec for the queue sidecar.
@@ -256,13 +235,32 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 	ports = append(ports, servingPort)
 
 	container := rev.Spec.GetContainer()
-	rp := container.ReadinessProbe.DeepCopy()
 
-	applyReadinessProbeDefaults(rp, userPort)
-
-	probeJSON, err := readiness.EncodeProbe(rp)
+	// During startup we want to poll the container faster than Kubernetes will
+	// allow, so we use an ExecProbe which starts immediately and then polls
+	// every 25ms. We encode the original probe as JSON in an environment
+	// variable for this probe to use.
+	userProbe := container.ReadinessProbe.DeepCopy()
+	applyReadinessProbeDefaultsForExec(userProbe, userPort)
+	execProbe := makeStartupExecProbe(userProbe, cfg.Deployment.ProgressDeadline)
+	userProbeJSON, err := readiness.EncodeProbe(userProbe)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize readiness probe: %w", err)
+	}
+
+	// After startup we'll directly use the same http health check endpoint the
+	// execprobe would have used (which will then check the user container).
+	// Unlike the StartupProbe, we don't need to override any of the
+	// timeouts/periods/thresholds here.
+	httpProbe := container.ReadinessProbe.DeepCopy()
+	httpProbe.Handler = corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Port: intstr.FromInt(int(servingPort.ContainerPort)),
+			HTTPHeaders: []corev1.HTTPHeader{{
+				Name:  network.ProbeHeaderName,
+				Value: queue.Name,
+			}},
+		},
 	}
 
 	return &corev1.Container{
@@ -270,7 +268,8 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		Image:           cfg.Deployment.QueueSidecarImage,
 		Resources:       createQueueResources(cfg.Deployment, rev.GetAnnotations(), container),
 		Ports:           ports,
-		ReadinessProbe:  makeQueueProbe(rp),
+		StartupProbe:    execProbe,
+		ReadinessProbe:  httpProbe,
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{
 			Name:  "SERVING_NAMESPACE",
@@ -348,7 +347,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Value: metrics.Domain(),
 		}, {
 			Name:  "SERVING_READINESS_PROBE",
-			Value: probeJSON,
+			Value: userProbeJSON,
 		}, {
 			Name:  "ENABLE_PROFILING",
 			Value: strconv.FormatBool(cfg.Observability.EnableProfiling),
@@ -362,7 +361,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 	}, nil
 }
 
-func applyReadinessProbeDefaults(p *corev1.Probe, port int32) {
+func applyReadinessProbeDefaultsForExec(p *corev1.Probe, port int32) {
 	switch {
 	case p == nil:
 		return

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -735,10 +735,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 						}},
 					},
 				},
-				// The ReadinessProbe does not override the user's probe parameters.
-				// (The aggressive probing will have happened on startup, now
-				// we can probe at the user-requested/default interval).
-				PeriodSeconds:    0,
+				PeriodSeconds:    1,
 				TimeoutSeconds:   0,
 				SuccessThreshold: 3,
 			}

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap/zapcore"
@@ -71,12 +72,14 @@ var (
 		InitialScale:          1,
 		AllowZeroInitialScale: false,
 	}
-	deploymentConfig deployment.Config
-	logConfig        logging.Config
-	obsConfig        metrics.ObservabilityConfig
-	traceConfig      tracingconfig.Config
-	defaults, _      = apicfg.NewDefaultsConfigFromMap(nil)
-	revCfg           = config.Config{
+	deploymentConfig = deployment.Config{
+		ProgressDeadline: 5678 * time.Second,
+	}
+	logConfig   logging.Config
+	obsConfig   metrics.ObservabilityConfig
+	traceConfig tracingconfig.Config
+	defaults, _ = apicfg.NewDefaultsConfigFromMap(nil)
+	revCfg      = config.Config{
 		Config: &apicfg.Config{
 			Autoscaler: &asConfig,
 			Defaults:   defaults,
@@ -102,6 +105,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		want corev1.Container
 	}{{
 		name: "autoscaler single",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("bar", "foo",
 			withContainers(containers),
 			withContainerConcurrency(1)),
@@ -122,11 +128,13 @@ func TestMakeQueueContainer(t *testing.T) {
 				}},
 			}})),
 		dc: deployment.Config{
+			ProgressDeadline:  5678 * time.Second,
 			QueueSidecarImage: "alpine",
 		},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Image = "alpine"
 			c.Ports = append(queueNonServingPorts, queueHTTP2Port)
+			c.ReadinessProbe.Handler.HTTPGet.Port.IntVal = queueHTTP2Port.ContainerPort
 			c.Env = env(map[string]string{
 				"USER_PORT":          "1955",
 				"QUEUE_SERVING_PORT": "8013",
@@ -134,6 +142,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		}),
 	}, {
 		name: "service name in labels",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("bar", "foo",
 			withContainers(containers),
 			func(revision *v1.Revision) {
@@ -148,6 +159,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		}),
 	}, {
 		name: "config owner as env var, zero concurrency",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("blah", "baz",
 			withContainers(containers),
 			withContainerConcurrency(0),
@@ -170,6 +184,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		}),
 	}, {
 		name: "logging configuration as env var",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("this", "log",
 			withContainers(containers)),
 		lc: logging.Config{
@@ -188,6 +205,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		}),
 	}, {
 		name: "container concurrency 10",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("bar", "foo",
 			withContainers(containers),
 			withContainerConcurrency(10)),
@@ -200,6 +220,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		name: "request log configuration as env var",
 		rev: revision("bar", "foo",
 			withContainers(containers)),
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		oc: metrics.ObservabilityConfig{
 			RequestLogTemplate:    "test template",
 			EnableProbeRequestLog: true,
@@ -214,6 +237,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		name: "disabled request log configuration as env var",
 		rev: revision("bar", "foo",
 			withContainers(containers)),
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		oc: metrics.ObservabilityConfig{
 			RequestLogTemplate:    "test template",
 			EnableProbeRequestLog: false,
@@ -230,6 +256,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		name: "request metrics backend as env var",
 		rev: revision("bar", "foo",
 			withContainers(containers)),
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		oc: metrics.ObservabilityConfig{
 			RequestMetricsBackend: "prometheus",
 		},
@@ -242,6 +271,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		name: "enable profiling",
 		rev: revision("bar", "foo",
 			withContainers(containers)),
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		oc: metrics.ObservabilityConfig{EnableProfiling: true},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
@@ -251,6 +283,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		}),
 	}, {
 		name: "custom TimeoutSeconds",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("bar", "foo",
 			withContainers(containers),
 			func(revision *v1.Revision) {
@@ -267,6 +302,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		rev: revision("bar", "foo",
 			withContainers(containers)),
 		dc: deployment.Config{
+			ProgressDeadline:       5678 * time.Second,
 			QueueSidecarCPURequest: &deployment.QueueSidecarCPURequestDefault,
 		},
 		want: queueContainer(func(c *corev1.Container) {
@@ -284,6 +320,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			QueueSidecarCPURequest:              resourcePtr(resource.MustParse("123m")),
 			QueueSidecarEphemeralStorageRequest: resourcePtr(resource.MustParse("456M")),
 			QueueSidecarMemoryLimit:             resourcePtr(resource.MustParse("789m")),
+			ProgressDeadline:                    5678 * time.Second,
 		},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{})
@@ -302,6 +339,9 @@ func TestMakeQueueContainer(t *testing.T) {
 		oc: metrics.ObservabilityConfig{
 			RequestMetricsBackend:   "opencensus",
 			MetricsCollectorAddress: "otel:55678",
+		},
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
 		},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
@@ -353,6 +393,9 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		dc   deployment.Config
 	}{{
 		name: "resources percentage in annotations",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
@@ -378,6 +421,9 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		}),
 	}, {
 		name: "resources percentage in annotations smaller than min allowed",
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
@@ -420,6 +466,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 				}}
 			}),
 		dc: deployment.Config{
+			ProgressDeadline:       5678 * time.Second,
 			QueueSidecarCPURequest: resourcePtr(resource.MustParse("25m")),
 		},
 		want: queueContainer(func(c *corev1.Container) {
@@ -446,6 +493,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 				}}
 			}),
 		dc: deployment.Config{
+			ProgressDeadline:       5678 * time.Second,
 			QueueSidecarCPURequest: resourcePtr(resource.MustParse("25m")),
 		},
 		want: queueContainer(func(c *corev1.Container) {
@@ -521,10 +569,15 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		c.Env = env(map[string]string{
 			"SERVING_READINESS_PROBE": string(wantProbeJSON),
 		})
+		c.StartupProbe = nil // User overrode periodSeconds so no exec probe needed.
 		c.ReadinessProbe = &corev1.Probe{
 			Handler: corev1.Handler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "10s"},
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+					HTTPHeaders: []corev1.HTTPHeader{{
+						Name:  network.ProbeHeaderName,
+						Value: queue.Name,
+					}},
 				},
 			},
 			PeriodSeconds:  1,
@@ -593,11 +646,17 @@ func TestProbeGenerationHTTP(t *testing.T) {
 			"USER_PORT":               strconv.Itoa(userPort),
 			"SERVING_READINESS_PROBE": string(wantProbeJSON),
 		})
+		c.StartupProbe = nil // User overrode periodSeconds so no execprobe needed.
 		c.ReadinessProbe = &corev1.Probe{
 			Handler: corev1.Handler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "10s"},
-				}},
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+					HTTPHeaders: []corev1.HTTPHeader{{
+						Name:  network.ProbeHeaderName,
+						Value: queue.Name,
+					}},
+				},
+			},
 			PeriodSeconds:  2,
 			TimeoutSeconds: 10,
 		}
@@ -651,14 +710,37 @@ func TestTCPProbeGeneration(t *testing.T) {
 			},
 		},
 		want: queueContainer(func(c *corev1.Container) {
-			c.ReadinessProbe = &corev1.Probe{
+			c.StartupProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "0"},
+						Command: []string{"/ko-app/queue", "-probe-period", "1h34m38s"},
 					},
 				},
-				PeriodSeconds:  10,
-				TimeoutSeconds: 10,
+				// StartupProbe overrides the user's parameters because the
+				// actual probing happens inside the execprobe.
+				// The timeout seconds is set to the progress deadline to match the
+				// timeout on initial deployment.
+				TimeoutSeconds:   5678,
+				PeriodSeconds:    1,
+				SuccessThreshold: 1,
+				FailureThreshold: 1,
+			}
+			c.ReadinessProbe = &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+						HTTPHeaders: []corev1.HTTPHeader{{
+							Name:  network.ProbeHeaderName,
+							Value: queue.Name,
+						}},
+					},
+				},
+				// The ReadinessProbe does not override the user's probe parameters.
+				// (The aggressive probing will have happened on startup, now
+				// we can probe at the user-requested/default interval).
+				PeriodSeconds:    0,
+				TimeoutSeconds:   0,
+				SuccessThreshold: 3,
 			}
 			c.Env = env(map[string]string{"USER_PORT": strconv.Itoa(userPort)})
 		}),
@@ -689,14 +771,20 @@ func TestTCPProbeGeneration(t *testing.T) {
 			TimeoutSeconds: 1,
 		},
 		want: queueContainer(func(c *corev1.Container) {
+			c.StartupProbe = nil // User overrode periodSeconds, no exec probe needed.
 			c.ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "1s"},
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+						HTTPHeaders: []corev1.HTTPHeader{{
+							Name:  network.ProbeHeaderName,
+							Value: queue.Name,
+						}},
 					},
 				},
-				PeriodSeconds:  1,
-				TimeoutSeconds: 1,
+				PeriodSeconds: 1,
+				// Inherit Kubernetes default here rather than overriding as we need to do for exec probe.
+				TimeoutSeconds: 0,
 			}
 			c.Env = env(map[string]string{})
 		}),
@@ -737,10 +825,15 @@ func TestTCPProbeGeneration(t *testing.T) {
 			},
 		},
 		want: queueContainer(func(c *corev1.Container) {
+			c.StartupProbe = nil // User overrode periodSeconds, no exec probe needed.
 			c.ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "15s"},
+					HTTPGet: &corev1.HTTPGetAction{
+						Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+						HTTPHeaders: []corev1.HTTPHeader{{
+							Name:  network.ProbeHeaderName,
+							Value: queue.Name,
+						}},
 					},
 				},
 				PeriodSeconds:       2,


### PR DESCRIPTION
As per title, this cherry-picks a fix for the activator to not get hung up on its stat reporting and also fixes to improve the cold start latency.

Some numbers for the latency:

## Current
```
Created 20 knative-head pods sequentially, results are in ms:

metric            |min  |max   |mean |p95   |p99
Time to scheduled |0    |14    |11   |14    |14
Time to ready     |5025 |13524 |9038 |12483 |13004
```

## Fixed
```
Created 20 knative-head pods sequentially, results are in ms:

metric            |min  |max  |mean |p95  |p99
Time to scheduled |2    |38   |13   |19   |28
Time to ready     |3737 |5395 |4651 |5338 |5366
```