### PR TITLE
Create `$KO_DATA_PATH/ingress/0.21` directory in knative-operator

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,12 +5,4 @@ source $(dirname $0)/resolve.sh
 release=$1
 output_file="openshift/release/knative-serving-${release}.yaml"
 
-if [ "$release" = "ci" ]; then
-    image_prefix="image-registry.openshift-image-registry.svc:5000/knative-serving/knative-serving-"
-    tag=""
-else
-    image_prefix="quay.io/openshift-knative/knative-serving-"
-    tag=$release
-fi
-
-resolve_resources "config/core/ config/hpa-autoscaling/ config/domain-mapping/" "$output_file" "$image_prefix" "$tag"
+resolve_resources "config/core/ config/hpa-autoscaling/ config/domain-mapping/" "$output_file"

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -3,38 +3,22 @@
 function resolve_resources(){
   local dir=$1
   local resolved_file_name=$2
-  local image_prefix=$3
-  local image_tag=$4
-
-  [[ -n $image_tag ]] && image_tag=":$image_tag"
 
   echo "Writing resolved yaml to $resolved_file_name"
 
   > "$resolved_file_name"
 
   for yaml in `find $dir -name "*.yaml" | sort`; do
-    resolve_file "$yaml" "$resolved_file_name" "$image_prefix" "$image_tag"
+    resolve_file "$yaml" "$resolved_file_name"
   done
 }
 
 function resolve_file() {
   local file=$1
   local to=$2
-  local image_prefix=$3
-  local image_tag=$4
-
-  # Skip cert-manager, it's not part of upstream's release YAML either.
-  if grep -q 'networking.knative.dev/certificate-provider: cert-manager' "$1"; then
-    return
-  fi
 
   # Skip nscert, it's not part of upstream's release YAML either.
   if grep -q 'networking.knative.dev/wildcard-certificate-provider: nscert' "$1"; then
-    return
-  fi
-
-  # Skip istio resources, as we use kourier.
-  if grep -q 'networking.knative.dev/ingress-provider: istio' "$1"; then
     return
   fi
 
@@ -42,8 +26,6 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
-      -e "s+\(.* queueSidecarImage: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
-      -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.20.0\"+" \
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.21.0\"+" \
       "$file" >> "$to"
 }


### PR DESCRIPTION
This patch creates `$KO_DATA_PATH/ingress/0.21` directory in knative-operator.
It is same workaround with https://github.com/openshift-knative/serverless-operator/pull/883/commits/c8bdcfe064f49552ef63a33324ea4493896140b8.

/cc @markusthoemmes @mgencur 