### PR TITLE
Use ytt command to apply test/config

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -275,10 +275,10 @@ function create_configmaps(){
 function prepare_knative_serving_tests_nightly {
   echo ">> Creating test resources for OpenShift (test/config/)"
 
-  # workaround until https://github.com/knative/operator/issues/431 was fixed.
-  rm -f test/config/config-deployment.yaml
-
-  oc apply -f test/config
+  run_ytt \
+    -f "test/config/ytt/lib" \
+    -f "test/config/ytt/values.yaml" \
+    -f test/config/ytt/core/resources.yaml | kubectl apply -f -
 
   oc adm policy add-scc-to-user privileged -z default -n serving-tests
   oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt


### PR DESCRIPTION
Since https://github.com/knative/serving/commit/e2a823714b032c2068fe5374ec0cd7bbac57522d, `test/config` directory needs ytt command.

This patch uses ytt.

/cc @markusthoemmes @mgencur 