### PR TITLE
wip - Mount empty configmap for knative-operator

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -181,8 +181,6 @@ EOF
 # The mounted kourier.yaml is not used but the manifest in "knative-openshift" via KOURIER_MANIFEST_PATH is used.
 # Mounting configmap because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
 # TODO: Use manifest in this knative-operator instead of knative-openshift's KOURIER_MANIFEST_PATH.
-  touch /tmp/empty.yaml
-  oc create configmap empty-cm -n $OPERATORS_NAMESPACE --from-file="/tmp/empty.yaml" || return $?
   cat << EOF | yq write --inplace --script - $CSV || return $?
 # kourier
 - command: update
@@ -194,11 +192,7 @@ EOF
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
     name: "kourier-manifest"
-    configMap:
-      name: "empty-cm"
-      items:
-        - key: "empty.yaml"
-          path: "empty.yaml"
+    emptyDir: {}
 EOF
 
 }

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -181,6 +181,8 @@ EOF
 # The mounted kourier.yaml is not used but the manifest in "knative-openshift" via KOURIER_MANIFEST_PATH is used.
 # Mounting configmap because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
 # TODO: Use manifest in this knative-operator instead of knative-openshift's KOURIER_MANIFEST_PATH.
+  touch /tmp/empty.yaml
+  oc create configmap empty-cm -n $OPERATORS_NAMESPACE --from-file="/tmp/empty.yaml" || return $?
   cat << EOF | yq write --inplace --script - $CSV || return $?
 # kourier
 - command: update
@@ -193,10 +195,10 @@ EOF
   value:
     name: "kourier-manifest"
     configMap:
-      name: "kourier-cm"
+      name: "empty-cm"
       items:
-        - key: "kourier.yaml"
-          path: "kourier.yaml"
+        - key: "empty.yaml"
+          path: "empty.yaml"
 EOF
 
 }

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -177,28 +177,6 @@ function update_csv(){
         - key: "kourier.yaml"
           path: "kourier.yaml"
 EOF
-
-# The mounted kourier.yaml is not used but the manifest in "knative-openshift" via KOURIER_MANIFEST_PATH is used.
-# Mounting configmap because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
-# TODO: Use manifest in this knative-operator instead of knative-openshift's KOURIER_MANIFEST_PATH.
-  cat << EOF | yq write --inplace --script - $CSV || return $?
-# kourier
-- command: update
-  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers[0].volumeMounts[+]
-  value:
-    name: "kourier-manifest"
-    mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
-- command: update
-  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
-  value:
-    name: "kourier-manifest"
-    configMap:
-      name: "kourier-cm"
-      items:
-        - key: "kourier.yaml"
-          path: "kourier.yaml"
-EOF
-
 }
 
 function install_catalogsource(){

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -177,6 +177,28 @@ function update_csv(){
         - key: "kourier.yaml"
           path: "kourier.yaml"
 EOF
+
+# The mounted kourier.yaml is not used but the manifest in "knative-openshift" via KOURIER_MANIFEST_PATH is used.
+# Mounting configmap because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
+# TODO: Use manifest in this knative-operator instead of knative-openshift's KOURIER_MANIFEST_PATH.
+  cat << EOF | yq write --inplace --script - $CSV || return $?
+# kourier
+- command: update
+  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers[0].volumeMounts[+]
+  value:
+    name: "kourier-manifest"
+    mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
+- command: update
+  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
+  value:
+    name: "kourier-manifest"
+    configMap:
+      name: "kourier-cm"
+      items:
+        - key: "kourier.yaml"
+          path: "kourier.yaml"
+EOF
+
 }
 
 function install_catalogsource(){


### PR DESCRIPTION
Previously configmap created with `kourier.yaml` is necessary to mount in knative-operator pod. This is just dummy file to create `ingress/MINOR_VERSION/` directory.

Now, downstream's knativeserving CR started to support `config.ingress` so the dummy file is used. So this patch changes the dummy file to empty file.