### PR TITLE
Mount emptyDir instead of Kourier manifest configmap in knaive-operator

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -178,25 +178,20 @@ function update_csv(){
           path: "kourier.yaml"
 EOF
 
-# The mounted kourier.yaml is not used but the manifest in "knative-openshift" via KOURIER_MANIFEST_PATH is used.
-# Mounting configmap because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
-# TODO: Use manifest in this knative-operator instead of knative-openshift's KOURIER_MANIFEST_PATH.
+# Mount emptyDir because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
+# The actual manifest is located in KOURIER_MANIFEST_PATH. Please see also SRVKS-721.
   cat << EOF | yq write --inplace --script - $CSV || return $?
 # kourier
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers[0].volumeMounts[+]
   value:
-    name: "kourier-manifest"
+    name: "ingress-directory"
     mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
-    name: "kourier-manifest"
-    configMap:
-      name: "kourier-cm"
-      items:
-        - key: "kourier.yaml"
-          path: "kourier.yaml"
+    name: "ingress-directory"
+    emptyDir: {}
 EOF
 
 }


### PR DESCRIPTION
Previously we mounted kourier.yaml in knative-operator pod. This is
just a dummy file to create `ingress/0.21/` directory and not used.
But now, serverless-operator supports `config.ingress` so the dummy
file was read by knative-operator and deploy Kourier pods in
knative-serving namespace.

To fix it, this patch uses emptyDir instead of mounting the configmap.

/cc @markusthoemmes @mgencur 