### PR TITLE
Remove test against test/e2e/multicontainer which does not exist

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -347,13 +347,6 @@ function run_e2e_tests(){
     --resolvabledomain "$(ingress_class)" || failed=1
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"tag-header-based-routing": "disabled"}}}}' || fail_test
 
-  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"multi-container": "enabled"}}}}' || fail_test
-  go_test_e2e -timeout=2m ./test/e2e/multicontainer \
-    --kubeconfig "$KUBECONFIG" \
-    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
-    --resolvabledomain "$(ingress_class)" || failed=1
-  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"multi-container": "disabled"}}}}' || fail_test
-
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "autoscaler": {"allow-zero-initial-scale": "true"}}}}' || fail_test
   # wait 10 sec until sync.
   sleep 10


### PR DESCRIPTION
Since https://github.com/knative/serving/commit/f8f26b7763a1ca81357b8ace86ea7853ecb3d507 moved multicontainer test into test/e2e, this removes test against `test/e2e/multicontainer`.

/cc @markusthoemmes @mgencur 