### PR TITLE
wip - Stop using KOURIER_MANIFEST_PATH

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -158,12 +158,7 @@ function update_csv(){
           path: "knative-eventing-ci.yaml"
 # kourier
 - command: update
-  path: spec.install.spec.deployments.(name==knative-openshift).spec.template.spec.containers.(name==knative-openshift).env.(name==KOURIER_MANIFEST_PATH)
-  value:
-    name: KOURIER_MANIFEST_PATH
-    value: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}/kourier.yaml"
-- command: update
-  path: spec.install.spec.deployments.(name==knative-openshift).spec.template.spec.containers[0].volumeMounts[+]
+  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "kourier-manifest"
     mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
@@ -177,23 +172,6 @@ function update_csv(){
         - key: "kourier.yaml"
           path: "kourier.yaml"
 EOF
-
-# Mount emptyDir because knative-operator needs KO_DATA_PATH/ingress/0.21 directory.
-# The actual manifest is located in KOURIER_MANIFEST_PATH. Please see also SRVKS-721.
-  cat << EOF | yq write --inplace --script - $CSV || return $?
-# kourier
-- command: update
-  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers[0].volumeMounts[+]
-  value:
-    name: "ingress-directory"
-    mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
-- command: update
-  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
-  value:
-    name: "ingress-directory"
-    emptyDir: {}
-EOF
-
 }
 
 function install_catalogsource(){

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -163,7 +163,7 @@ function update_csv(){
     name: "kourier-manifest"
     mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
 - command: update
-  path: spec.install.spec.deployments.(name==knative-openshift).spec.template.spec.volumes[+]
+  path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
     name: "kourier-manifest"
     configMap:

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -42,7 +42,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 
@@ -92,7 +92,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -107,7 +107,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -122,7 +122,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -147,7 +147,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: [""]
@@ -197,7 +197,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 
@@ -233,14 +233,14 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -252,7 +252,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -267,7 +267,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -347,7 +347,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -404,7 +404,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1092,7 +1092,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1150,7 +1150,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1271,7 +1271,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1429,7 +1429,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2120,7 +2120,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2292,7 +2292,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2361,7 +2361,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3115,7 +3115,7 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -3141,7 +3141,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:
@@ -3345,7 +3345,7 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "cdabec96"
 data:
@@ -3478,7 +3478,7 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "fa67b403"
 data:
@@ -3558,7 +3558,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -3620,7 +3620,7 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "1bbf8144"
 data:
@@ -3748,7 +3748,7 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "e6149382"
 data:
@@ -3845,7 +3845,7 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
@@ -3904,7 +3904,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "d9570453"
 data:
@@ -3981,7 +3981,7 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "15954d34"
 data:
@@ -4113,7 +4113,7 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "97c1d10b"
 data:
@@ -4232,7 +4232,7 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "4002b4c2"
 data:
@@ -4291,7 +4291,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4317,7 +4317,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4344,7 +4344,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -4357,7 +4357,7 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -4451,7 +4451,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     app: activator
@@ -4491,7 +4491,7 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   replicas: 1
   selector:
@@ -4503,7 +4503,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4588,7 +4588,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -4626,7 +4626,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -4637,7 +4637,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4703,7 +4703,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -4738,7 +4738,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -4762,7 +4762,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4789,7 +4789,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -4802,7 +4802,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4891,7 +4891,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -4928,7 +4928,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -4963,7 +4963,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5015,7 +5015,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5069,7 +5069,7 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -5091,7 +5091,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -5139,7 +5139,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -5199,7 +5199,7 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -5210,7 +5210,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5280,13 +5280,121 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.domainmapping.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.22.0"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: domainmapping-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: webhook.domainmapping.serving.knative.dev
+  timeoutSeconds: 10
+  rules:
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    scope: "*"
+    resources:
+    - domainmappings
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: domainmapping-webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.22.0"
+# The data is populated at install time.
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.domainmapping.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.22.0"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: domainmapping-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: validation.webhook.domainmapping.serving.knative.dev
+  timeoutSeconds: 10
+  rules:
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+      - v1alpha1
+    operations:
+      - CREATE
+      - UPDATE
+      - DELETE
+    scope: "*"
+    resources:
+    - domainmappings
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -5299,7 +5407,7 @@ spec:
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5386,7 +5494,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5403,114 +5511,6 @@ spec:
     targetPort: 8443
   selector:
     role: domainmapping-webhook
----
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: webhook.domainmapping.serving.knative.dev
-  labels:
-    serving.knative.dev/release: "v0.21.0"
-webhooks:
-- admissionReviewVersions: ["v1", "v1beta1"]
-  clientConfig:
-    service:
-      name: domainmapping-webhook
-      namespace: knative-serving
-  failurePolicy: Fail
-  sideEffects: None
-  name: webhook.domainmapping.serving.knative.dev
-  timeoutSeconds: 10
-  rules:
-  - apiGroups:
-    - serving.knative.dev
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    scope: "*"
-    resources:
-    - domainmappings
----
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: v1
-kind: Secret
-metadata:
-  name: domainmapping-webhook-certs
-  namespace: knative-serving
-  labels:
-    serving.knative.dev/release: "v0.21.0"
-# The data is populated at install time.
----
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: validation.webhook.domainmapping.serving.knative.dev
-  labels:
-    serving.knative.dev/release: "v0.21.0"
-webhooks:
-- admissionReviewVersions: ["v1", "v1beta1"]
-  clientConfig:
-    service:
-      name: domainmapping-webhook
-      namespace: knative-serving
-  failurePolicy: Fail
-  sideEffects: None
-  name: validation.webhook.domainmapping.serving.knative.dev
-  timeoutSeconds: 10
-  rules:
-  - apiGroups:
-    - serving.knative.dev
-    apiVersions:
-      - v1alpha1
-    operations:
-      - CREATE
-      - UPDATE
-      - DELETE
-    scope: "*"
-    resources:
-    - domainmappings
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -5532,7 +5532,7 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   selector:
@@ -5544,7 +5544,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: "v0.21.0"
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5606,7 +5606,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    serving.knative.dev/release: "v0.21.0"
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
   name: autoscaler-hpa
   namespace: knative-serving

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -26,6 +26,6 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.21.0\"+" \
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.22.0\"+" \
       "$file" >> "$to"
 }


### PR DESCRIPTION
This patch stops using KOURIER_MANIFEST_PATH but upstream's way supported by https://github.com/openshift-knative/serverless-operator/commit/f4d65e6c0b6c593473922bbde2c4c7c6066deb34 