### PR TITLE
Fix condition in update-to-head script

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -35,7 +35,7 @@ if hash hub 2>/dev/null; then
    # Test if there is already a sync PR in 
    COUNT=$(hub api -H "Accept: application/vnd.github.v3+json" repos/openshift/${REPO_NAME}/pulls --flat \
     | grep -c ":robot: Triggering CI on branch 'release-next' after synching to upstream/main")
-   if [ "$COUNT" == "0" ]; then 
+   if [ "$COUNT" = "0" ]; then
       hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
    fi
 else


### PR DESCRIPTION
Double `==` is not allowed with single brackets (POSIX form)