### PR TITLE
Do not fail update-to-head if there are not PRs

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -34,7 +34,7 @@ git push -f openshift release-next-ci
 if hash hub 2>/dev/null; then
    # Test if there is already a sync PR in 
    COUNT=$(hub api -H "Accept: application/vnd.github.v3+json" repos/openshift/${REPO_NAME}/pulls --flat \
-    | grep -c ":robot: Triggering CI on branch 'release-next' after synching to upstream/main")
+    | grep -c ":robot: Triggering CI on branch 'release-next' after synching to upstream/main") || true
    if [ "$COUNT" = "0" ]; then
       hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
    fi


### PR DESCRIPTION
* the grep command returned non-zero status code and the -e flag was
making the script fail immediately