### PR TITLE
[BACKPORT][0.22.0] Fix websocket test with https option

### DIFF
--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -56,10 +56,23 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 	}
 
 	u := url.URL{Scheme: "ws", Host: net.JoinHostPort(address, mapper("80")), Path: "/"}
+	if test.ServingFlags.HTTPS {
+		u = url.URL{Scheme: "wss", Host: net.JoinHostPort(address, mapper("443")), Path: "/"}
+	}
+
 	var conn *websocket.Conn
 	waitErr := wait.PollImmediate(connectRetryInterval, connectTimeout, func() (bool, error) {
 		t.Logf("Connecting using websocket: url=%s, host=%s", u.String(), domain)
-		c, resp, err := websocket.DefaultDialer.Dial(u.String(), http.Header{"Host": {domain}})
+		dialer := &websocket.Dialer{
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: 45 * time.Second,
+		}
+		if test.ServingFlags.HTTPS {
+			dialer.TLSClientConfig = test.TLSClientConfig(context.Background(), t.Logf, clients)
+			dialer.TLSClientConfig.ServerName = domain // Set ServerName for pseudo hostname with TLS.
+		}
+
+		c, resp, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
 		if err == nil {
 			t.Log("WebSocket connection established.")
 			conn = c

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -46,13 +46,13 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 		address string
 	)
 
-	address, mapper, err := ingress.GetIngressEndpoint(context.Background(), clients.KubeClient, pkgTest.Flags.IngressEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	if test.ServingFlags.ResolvableDomain {
-		address = domain
-		mapper = func(in string) string { return in }
+	address = domain
+	mapper := func(in string) string { return in }
+	if !test.ServingFlags.ResolvableDomain {
+		address, mapper, err = ingress.GetIngressEndpoint(context.Background(), clients.KubeClient, pkgTest.Flags.IngressEndpoint)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	u := url.URL{Scheme: "ws", Host: net.JoinHostPort(address, mapper("80")), Path: "/"}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -122,7 +122,11 @@ func webSocketResponseFreqs(t *testing.T, clients *test.Clients, url string, num
 // (3) sends a message, and
 // (4) verifies that we receive back the same message.
 func TestWebSocket(t *testing.T) {
-	t.Parallel()
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 
 	clients := Setup(t)
 
@@ -146,7 +150,11 @@ func TestWebSocket(t *testing.T) {
 
 // and with -1 as target burst capacity and then validates that we can still serve.
 func TestWebSocketViaActivator(t *testing.T) {
-	t.Parallel()
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 
 	clients := Setup(t)
 
@@ -182,12 +190,22 @@ func TestWebSocketViaActivator(t *testing.T) {
 }
 
 func TestWebSocketBlueGreenRoute(t *testing.T) {
-	t.Parallel()
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 	clients := test.Setup(t)
+
+	svcName := test.ObjectNameForTest(t)
+	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
+	if test.ServingFlags.HTTPS {
+		svcName = test.AppendRandomString("web-socket-blue-green")
+	}
 
 	names := test.ResourceNames{
 		// Set Service and Image for names to create the initial service
-		Service: test.ObjectNameForTest(t),
+		Service: svcName,
 		Image:   wsServerTestImageName,
 	}
 


### PR DESCRIPTION
This patch cherry-pick upstream tests:
- 4cdc1530953687149c4c0d806199cd0419b1462c
- b16d6b478e7894f937e4a65d960a02fec003517e

/cc @markusthoemmes @mgencur 