### PR TITLE
[CP][0.22] Add https option to activator ha test

### DIFF
--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -96,7 +96,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 	}
 
 	t.Log("Starting prober")
-	prober := test.NewProberManager(t.Logf, clients, minProbes)
+	prober := test.NewProberManager(t.Logf, clients, minProbes, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 	prober.Spawn(resources.Service.Status.URL.URL())
 	defer assertSLO(t, prober, slo)
 

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -69,7 +69,9 @@ func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names tes
 		url,
 		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
-		resolvabledomain); err != nil {
+		resolvabledomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
 		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 }


### PR DESCRIPTION
This patch backports https://github.com/knative/serving/commit/8062d8601fcb565c165f6f215aee4128e0ca9055 to 0.22 branch.