### PR TITLE
Use golang 1.15 image from registry to avoid docker rate limiting

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.15
+FROM registry.ci.openshift.org/openshift/release:golang-1.15
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
As per title. A bit of cleanup.