### PR TITLE
Toggle autocreateClusterDomainClaims before test

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -220,6 +220,9 @@ spec:
         "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
       logging.enable-probe-request-log: "true"
       logging.enable-request-log: "true"
+  deployments:
+  - name: domain-mapping
+    replicas: 2
 EOF
 
   # Wait for 4 pods to appear first

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -310,6 +310,7 @@ function run_e2e_tests(){
     parallel=2
   fi
 
+  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "network": {"autocreateClusterDomainClaims": "true"}}}}' || fail_test
   go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --kubeconfig "$KUBECONFIG" \
@@ -317,6 +318,7 @@ function run_e2e_tests(){
     --enable-alpha \
     --enable-beta \
     --resolvabledomain || failed=1
+  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "network": {"autocreateClusterDomainClaims": "false"}}}}' || fail_test
 
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"tag-header-based-routing": "enabled"}}}}' || fail_test
   go_test_e2e -timeout=2m ./test/e2e/tagheader \
@@ -360,12 +362,16 @@ function run_e2e_tests(){
 
   # Run HA tests separately as they're stopping core Knative Serving pods
   # Define short -spoofinterval to ensure frequent probing while stopping pods
+  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "network": {"autocreateClusterDomainClaims": "true"}}}}' || fail_test
   go_test_e2e -tags=e2e -timeout=15m -failfast -parallel=1 \
     ./test/ha \
     -replicas="${OPENSHIFT_REPLICAS}" -buckets="${OPENSHIFT_BUCKETS}" -spoofinterval="10ms" \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --enable-alpha \
+    --enable-beta \
     --resolvabledomain || failed=3
+  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "network": {"autocreateClusterDomainClaims": "false"}}}}' || fail_test
 
   return $failed
 }


### PR DESCRIPTION
This patch toggles `autocreateClusterDomainClaims` before test.
Also current test missed domainmapping HA due to missing `--enable-alpha` so this patch added.

/cc @markusthoemmes @mgencur  