### PR TITLE
Use customdomain option

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -291,6 +291,7 @@ function run_e2e_tests(){
 
   # Give the controller time to sync with the rest of the system components.
   sleep 30
+  subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}"
 
   if [ -n "$test_name" ]; then
     go_test_e2e -tags=e2e -timeout=15m -parallel=1 \
@@ -300,6 +301,7 @@ function run_e2e_tests(){
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --enable-alpha \
     --enable-beta \
+    --customdomain=$subdomain \
     --resolvabledomain || failed=$?
 
     return $failed
@@ -320,6 +322,7 @@ function run_e2e_tests(){
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --enable-alpha \
     --enable-beta \
+    --customdomain=$subdomain \
     --resolvabledomain || failed=1
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "network": {"autocreateClusterDomainClaims": "false"}}}}' || fail_test
 
@@ -373,6 +376,7 @@ function run_e2e_tests(){
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --enable-alpha \
     --enable-beta \
+    --customdomain=$subdomain \
     --resolvabledomain || failed=3
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "network": {"autocreateClusterDomainClaims": "false"}}}}' || fail_test
 


### PR DESCRIPTION
DomainMapping test needs two domain like:

- `original-ksvc-ns.serverless.devcluster.openshift.com`
- `mydomain.example.com`

We have a wildcard DNS for `*.serverless.devcluster.openshift.com` but cannot prepare for DNS the second domain `mydomain.example.com` so we used spoof client for the second domain `mydomain.example.com`.
But if we changed the second domain to the same subdomain like `original-ksvc.serverless.devcluster.openshift.com` by `--customdomain` option, it works.

/cc @markusthoemmes @mgencur 