### PR TITLE
[WIP][TESTONLY] Do not modify release label

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -79,6 +79,8 @@ function update_csv(){
   local SERVING_DIR=$1
 
   source ./hack/lib/metadata.bash
+  local SERVING_VERSION=$(metadata.get dependencies.serving)
+  local EVENTING_VERSION=$(metadata.get dependencies.eventing)
   local KOURIER_VERSION=$(metadata.get dependencies.kourier)
   local KOURIER_MINOR_VERSION=${KOURIER_VERSION%.*}    # e.g. "0.21.0" => "0.21"
 
@@ -116,7 +118,7 @@ function update_csv(){
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "serving-manifest"
-    mountPath: "/tmp/knative/knative-serving/latest"
+    mountPath: "/tmp/knative/knative-serving/${SERVING_VERSION}"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
@@ -131,7 +133,7 @@ function update_csv(){
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "eventing-manifest"
-    mountPath: "/tmp/knative/knative-eventing/latest"
+    mountPath: "/tmp/knative/knative-eventing/${EVENTING_VERSION}"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
@@ -146,7 +148,7 @@ function update_csv(){
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "kourier-manifest"
-    mountPath: "/tmp/knative/ingress/latest"
+    mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
@@ -193,7 +195,6 @@ metadata:
   name: knative-serving
   namespace: ${SERVING_NAMESPACE}
 spec:
-  version: latest
   config:
     deployment:
       progressDeadline: "120s"

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -79,8 +79,6 @@ function update_csv(){
   local SERVING_DIR=$1
 
   source ./hack/lib/metadata.bash
-  local SERVING_VERSION=$(metadata.get dependencies.serving)
-  local EVENTING_VERSION=$(metadata.get dependencies.eventing)
   local KOURIER_VERSION=$(metadata.get dependencies.kourier)
   local KOURIER_MINOR_VERSION=${KOURIER_VERSION%.*}    # e.g. "0.21.0" => "0.21"
 
@@ -118,7 +116,7 @@ function update_csv(){
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "serving-manifest"
-    mountPath: "/tmp/knative/knative-serving/${SERVING_VERSION}"
+    mountPath: "/tmp/knative/knative-serving/latest"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
@@ -133,7 +131,7 @@ function update_csv(){
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "eventing-manifest"
-    mountPath: "/tmp/knative/knative-eventing/${EVENTING_VERSION}"
+    mountPath: "/tmp/knative/knative-eventing/latest"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
@@ -148,7 +146,7 @@ function update_csv(){
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.containers.(name==knative-operator).volumeMounts[+]
   value:
     name: "kourier-manifest"
-    mountPath: "/tmp/knative/ingress/${KOURIER_MINOR_VERSION}"
+    mountPath: "/tmp/knative/ingress/latest"
 - command: update
   path: spec.install.spec.deployments.(name==knative-operator).spec.template.spec.volumes[+]
   value:
@@ -195,6 +193,7 @@ metadata:
   name: knative-serving
   namespace: ${SERVING_NAMESPACE}
 spec:
+  version: latest
   config:
     deployment:
       progressDeadline: "120s"

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,4 +5,4 @@ source $(dirname $0)/resolve.sh
 release=$1
 output_file="openshift/release/knative-serving-${release}.yaml"
 
-resolve_resources "config/core/ config/hpa-autoscaling/ config/domain-mapping/" "$output_file"
+resolve_resources "config/core/ config/hpa-autoscaling/" "$output_file"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -42,7 +42,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 
@@ -92,7 +92,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -107,7 +107,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -122,7 +122,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -147,7 +147,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: [""]
@@ -200,7 +200,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 
@@ -236,14 +236,14 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -255,7 +255,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -270,7 +270,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -350,7 +350,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -407,7 +407,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1104,7 +1104,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1152,7 +1152,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1304,7 +1304,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1362,7 +1362,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1483,7 +1483,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1641,7 +1641,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2341,7 +2341,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2513,7 +2513,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2582,7 +2582,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3345,7 +3345,7 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -3371,7 +3371,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:
@@ -3575,7 +3575,7 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "cdabec96"
 data:
@@ -3708,7 +3708,7 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "fa67b403"
 data:
@@ -3788,7 +3788,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -3850,7 +3850,7 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "8c1f8302"
 data:
@@ -3984,7 +3984,7 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "e6149382"
 data:
@@ -4081,7 +4081,7 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
@@ -4140,7 +4140,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "c68feb1b"
 data:
@@ -4217,7 +4217,7 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "d38faef1"
 data:
@@ -4358,7 +4358,7 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "97c1d10b"
 data:
@@ -4477,7 +4477,7 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   annotations:
     knative.dev/example-checksum: "4002b4c2"
 data:
@@ -4536,7 +4536,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4562,7 +4562,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4589,7 +4589,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   selector:
     matchLabels:
@@ -4602,7 +4602,7 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -4696,7 +4696,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   selector:
     app: activator
@@ -4736,7 +4736,7 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   replicas: 1
   selector:
@@ -4748,7 +4748,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4833,7 +4833,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -4871,7 +4871,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   selector:
     matchLabels:
@@ -4882,7 +4882,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4948,7 +4948,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -4983,7 +4983,7 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   selector:
     matchLabels:
@@ -4994,7 +4994,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5070,7 +5070,7 @@ metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   selector:
     matchLabels:
@@ -5083,7 +5083,7 @@ spec:
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5176,7 +5176,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5214,7 +5214,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5238,7 +5238,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   minAvailable: 80%
   selector:
@@ -5265,7 +5265,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 spec:
   selector:
     matchLabels:
@@ -5278,7 +5278,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5373,7 +5373,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -5410,7 +5410,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5445,7 +5445,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5497,7 +5497,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5540,7 +5540,7 @@ metadata:
   name: domainmapping-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -5562,7 +5562,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5605,7 +5605,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5659,7 +5659,7 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
 # The data is populated at install time.
 ---
 # Copyright 2019 The Knative Authors
@@ -5682,7 +5682,7 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   selector:
@@ -5694,7 +5694,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: "v0.23.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5756,7 +5756,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: "v0.23.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
   name: autoscaler-hpa
   namespace: knative-serving

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -42,7 +42,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 
@@ -92,7 +92,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -107,7 +107,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -122,7 +122,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -147,7 +147,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: [""]
@@ -200,7 +200,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 
@@ -236,14 +236,14 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -255,7 +255,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -270,7 +270,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -350,7 +350,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -407,7 +407,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1104,7 +1104,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1152,7 +1152,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1304,7 +1304,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1362,7 +1362,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1483,7 +1483,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1641,7 +1641,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2341,7 +2341,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2513,7 +2513,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2582,7 +2582,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3345,7 +3345,7 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -3371,7 +3371,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:
@@ -3575,7 +3575,7 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "cdabec96"
 data:
@@ -3708,7 +3708,7 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "fa67b403"
 data:
@@ -3788,7 +3788,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -3850,7 +3850,7 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "8c1f8302"
 data:
@@ -3984,7 +3984,7 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "e6149382"
 data:
@@ -4081,7 +4081,7 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
@@ -4140,7 +4140,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "c68feb1b"
 data:
@@ -4217,7 +4217,7 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "d38faef1"
 data:
@@ -4358,7 +4358,7 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "97c1d10b"
 data:
@@ -4477,7 +4477,7 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "4002b4c2"
 data:
@@ -4536,7 +4536,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4562,7 +4562,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:
@@ -4589,7 +4589,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -4602,7 +4602,7 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:
@@ -4696,7 +4696,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   selector:
     app: activator
@@ -4736,7 +4736,7 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -4748,7 +4748,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4833,7 +4833,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -4871,7 +4871,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -4882,7 +4882,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4948,7 +4948,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   name: controller
   namespace: knative-serving
 spec:
@@ -4983,7 +4983,7 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -4994,7 +4994,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5070,7 +5070,7 @@ metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -5083,7 +5083,7 @@ spec:
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5176,7 +5176,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5214,7 +5214,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5238,7 +5238,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:
@@ -5265,7 +5265,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -5278,7 +5278,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5373,7 +5373,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
   name: webhook
   namespace: knative-serving
 spec:
@@ -5410,7 +5410,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5445,7 +5445,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5497,7 +5497,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5540,7 +5540,7 @@ metadata:
   name: domainmapping-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -5562,7 +5562,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5605,7 +5605,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5659,7 +5659,7 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
 # The data is populated at install time.
 ---
 # Copyright 2019 The Knative Authors
@@ -5682,7 +5682,7 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   selector:
@@ -5694,7 +5694,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: "v0.22.0"
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5756,7 +5756,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    serving.knative.dev/release: "v0.22.0"
+    serving.knative.dev/release: devel
     autoscaling.knative.dev/autoscaler-provider: hpa
   name: autoscaler-hpa
   namespace: knative-serving

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -18,7 +18,7 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -42,7 +42,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
 
@@ -92,7 +92,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -107,7 +107,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -122,7 +122,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
@@ -147,7 +147,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: [""]
@@ -200,7 +200,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
 
@@ -236,14 +236,14 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -255,7 +255,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -270,7 +270,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -350,7 +350,7 @@ kind: CustomResourceDefinition
 metadata:
   name: certificates.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -407,7 +407,7 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1104,7 +1104,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1152,7 +1152,7 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1304,7 +1304,7 @@ kind: CustomResourceDefinition
 metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1362,7 +1362,7 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1483,7 +1483,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1641,7 +1641,7 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2341,7 +2341,7 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2513,7 +2513,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2582,7 +2582,7 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3345,7 +3345,7 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -3371,7 +3371,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:
@@ -3575,7 +3575,7 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "cdabec96"
 data:
@@ -3708,7 +3708,7 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "fa67b403"
 data:
@@ -3788,7 +3788,7 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -3850,7 +3850,7 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "8c1f8302"
 data:
@@ -3984,7 +3984,7 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "e6149382"
 data:
@@ -4081,7 +4081,7 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
@@ -4140,7 +4140,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "c68feb1b"
 data:
@@ -4217,7 +4217,7 @@ metadata:
   name: config-network
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "d38faef1"
 data:
@@ -4358,7 +4358,7 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "97c1d10b"
 data:
@@ -4477,7 +4477,7 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   annotations:
     knative.dev/example-checksum: "4002b4c2"
 data:
@@ -4536,7 +4536,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4562,7 +4562,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4589,7 +4589,7 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -4602,7 +4602,7 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -4696,7 +4696,7 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     app: activator
@@ -4736,7 +4736,7 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   replicas: 1
   selector:
@@ -4748,7 +4748,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4833,7 +4833,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -4871,7 +4871,7 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -4882,7 +4882,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -4948,7 +4948,7 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -4983,7 +4983,7 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -4994,7 +4994,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5070,7 +5070,7 @@ metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -5083,7 +5083,7 @@ spec:
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5176,7 +5176,7 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5214,7 +5214,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5238,7 +5238,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   minAvailable: 80%
   selector:
@@ -5265,7 +5265,7 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 spec:
   selector:
     matchLabels:
@@ -5278,7 +5278,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5373,7 +5373,7 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
   name: webhook
   namespace: knative-serving
 spec:
@@ -5410,7 +5410,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5445,7 +5445,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5497,7 +5497,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5540,7 +5540,7 @@ metadata:
   name: domainmapping-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -5562,7 +5562,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5605,7 +5605,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5659,7 +5659,7 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
 # The data is populated at install time.
 ---
 # Copyright 2019 The Knative Authors
@@ -5682,7 +5682,7 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
 spec:
   selector:
@@ -5694,7 +5694,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
-        serving.knative.dev/release: devel
+        serving.knative.dev/release: "v0.22.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5756,7 +5756,7 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    serving.knative.dev/release: devel
+    serving.knative.dev/release: "v0.22.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
   name: autoscaler-hpa
   namespace: knative-serving

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -26,6 +26,6 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.22.0\"+" \
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.23.0\"+" \
       "$file" >> "$to"
 }

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -23,5 +23,9 @@ function resolve_file() {
   fi
 
   echo "---" >> "$to"
-  cat "$file" >> "$to"
+  # 1. Rewrite image references
+  # 2. Update config map entry
+  # 3. Replace serving.knative.dev/release label.
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.22.0\"+" \
+      "$file" >> "$to"
 }

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -23,9 +23,5 @@ function resolve_file() {
   fi
 
   echo "---" >> "$to"
-  # 1. Rewrite image references
-  # 2. Update config map entry
-  # 3. Replace serving.knative.dev/release label.
-  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.22.0\"+" \
-      "$file" >> "$to"
+  cat "$file" >> "$to"
 }


### PR DESCRIPTION
As https://github.com/knative/operator/commit/5f894abf72b278bb2bcea41a38eba0d3da30958e was available on 0.23, we don't need to modify the release label.