### PR TITLE
Add v0.23 label to manifests

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,4 +5,4 @@ source $(dirname $0)/resolve.sh
 release=$1
 output_file="openshift/release/knative-serving-${release}.yaml"
 
-resolve_resources "config/core/ config/hpa-autoscaling/ config/domain-mapping/" "$output_file"
+resolve_resources "config/core/ config/hpa-autoscaling/" "$output_file"

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -26,6 +26,6 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.22.0\"+" \
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v0.23.0\"+" \
       "$file" >> "$to"
 }


### PR DESCRIPTION
This patch updates label in manifests to 0.23 for the version mismatch issue by knative-operator.

/cc @markusthoemmes @mgencur 