### PR TITLE
[RELEASE-0.24.0][BACKPORT] Fix scrape_time metric registration

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -77,7 +77,7 @@ var (
 )
 
 func init() {
-	if err := view.Register(
+	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
 			Description: "The time to scrape metrics in milliseconds",
 			Measure:     scrapeTimeM,


### PR DESCRIPTION
This is required by https://github.com/openshift-knative/serverless-operator/pull/1137.
Serverless 1.18 will ship with v0.24.0 afaik.