### PR TITLE
Call create_namespaces with arg SYSTEM_NAMESPACES

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -194,7 +194,7 @@ function install_catalogsource(){
   pushd ${SERVERLESS_DIR}
 
   source ./test/lib.bash
-  create_namespaces
+  create_namespaces "${SYSTEM_NAMESPACES[@]}"
   update_csv $CURRENT_DIR || return $?
   # Make OPENSHIFT_CI empty to use nightly build images.
   OPENSHIFT_CI="" ensure_catalogsource_installed || return $?


### PR DESCRIPTION
* This is required after merging
https://github.com/openshift-knative/serverless-operator/commit/c76313f15a3a612a1a38b812dcfa8f688fdf00c6#diff-051375546db9782[…]3dd8634ca5b2c8968bb8
which separates system and test namespaces, so it is required to choose
system ns