### PR TITLE
[release-v1.0.1] Upgrade tests - properly clean up resources  (#12395)

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -194,7 +194,7 @@ function install_catalogsource(){
   pushd ${SERVERLESS_DIR}
 
   source ./test/lib.bash
-  create_namespaces
+  create_namespaces "${SYSTEM_NAMESPACES[@]}"
   update_csv $CURRENT_DIR || return $?
   # Make OPENSHIFT_CI empty to use nightly build images.
   OPENSHIFT_CI="" ensure_catalogsource_installed || return $?

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -17,18 +17,11 @@ limitations under the License.
 package upgrade
 
 import (
-	"context"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ptest "knative.dev/pkg/test"
-
 	pkgupgrade "knative.dev/pkg/test/upgrade"
-	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
-	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
-	v1test "knative.dev/serving/test/v1"
 )
 
 // ServingPostDowngradeTests is an umbrella function for grouping all Serving post-downgrade tests.
@@ -48,49 +41,18 @@ func ServicePostDowngradeTest() pkgupgrade.Operation {
 
 func servicePostDowngrade(t *testing.T) {
 	t.Parallel()
-	clients := e2e.Setup(t)
-
-	names := test.ResourceNames{
-		Service: serviceName,
-	}
-
-	t.Logf("Getting service %q", names.Service)
-	svc, err := clients.ServingClient.Services.Get(context.Background(), names.Service, metav1.GetOptions{})
-	if err != nil {
-		t.Fatal("Failed to get Service:", err)
-	}
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
-	names.Revision = svc.Status.LatestCreatedRevisionName
-
-	url := svc.Status.URL
-
-	t.Log("Check that we can hit the old service and get the old response.")
-	assertServiceResourcesUpdated(t, clients, names, url.URL(), test.PizzaPlanetText2)
-
-	t.Log("Updating the Service to use a different image")
-	newImage := ptest.ImagePath(test.PizzaPlanet1)
-	if _, err := v1test.PatchService(t, clients, svc, rtesting.WithServiceImage(newImage)); err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, newImage, err)
-	}
-
-	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	revisionName, err := v1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, test.PizzaPlanet1, err)
-	}
-	names.Revision = revisionName
-
-	t.Log("When the Service reports as Ready, everything should be ready.")
-	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
-	}
-	assertServiceResourcesUpdated(t, clients, names, url.URL(), test.PizzaPlanetText1)
+	test.EnsureTearDown(t, e2e.Setup(t), &upgradeServiceNames)
+	updateServiceAndCheck(t,
+		upgradeServiceNames.Service,
+		test.PizzaPlanet1,
+		test.PizzaPlanetText2,
+		test.PizzaPlanetText1,
+	)
 }
 
 // CreateNewServicePostDowngradeTest verifies creating a new service after downgrade.
 func CreateNewServicePostDowngradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("CreateNewServicePostDowngradeTest", func(c pkgupgrade.Context) {
-		createNewService(postDowngradeServiceName, c.T)
+		createNewService("pizzaplanet-post-downgrade-service", c.T)
 	})
 }

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -58,18 +58,22 @@ func servicePostUpgrade(t *testing.T) {
 
 	// Before updating the service, the route and configuration objects should
 	// not be updated just because there has been an upgrade.
-	if hasGeneration, err := configHasGeneration(clients, serviceName, 1); err != nil {
+	if hasGeneration, err := configHasGeneration(clients, upgradeServiceNames.Service, 1); err != nil {
 		t.Fatal("Error comparing Configuration generation", err)
 	} else if !hasGeneration {
 		t.Fatal("Configuration is updated after an upgrade.")
 	}
-	if hasGeneration, err := routeHasGeneration(clients, serviceName, 1); err != nil {
+	if hasGeneration, err := routeHasGeneration(clients, upgradeServiceNames.Service, 1); err != nil {
 		t.Fatal("Error comparing Route generation", err)
 	} else if !hasGeneration {
 		t.Fatal("Route is updated after an upgrade.")
 	}
-
-	updateService(serviceName, t)
+	updateServiceAndCheck(t,
+		upgradeServiceNames.Service,
+		test.PizzaPlanet2,
+		test.PizzaPlanetText1,
+		test.PizzaPlanetText2,
+	)
 }
 
 func configHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
@@ -91,7 +95,13 @@ func routeHasGeneration(clients *test.Clients, serviceName string, generation in
 // ServicePostUpgradeFromScaleToZeroTest verifies a scaled-to-zero service after upgrade.
 func ServicePostUpgradeFromScaleToZeroTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("PostUpgradeFromScaleToZeroTest", func(c pkgupgrade.Context) {
-		updateService(scaleToZeroServiceName, c.T)
+		test.EnsureTearDown(c.T, e2e.Setup(c.T), &scaleToZeroServiceNames)
+		updateServiceAndCheck(c.T,
+			scaleToZeroServiceNames.Service,
+			test.PizzaPlanet2,
+			test.PizzaPlanetText1,
+			test.PizzaPlanetText2,
+		)
 	})
 }
 
@@ -106,11 +116,9 @@ func BYORevisionPostUpgradeTest() pkgupgrade.Operation {
 func bYORevisionPostUpgrade(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
-	names := test.ResourceNames{
-		Service: byoServiceName,
-	}
+	test.EnsureTearDown(t, clients, &byoServiceNames)
 
-	if _, err := v1test.PatchServiceRouteSpec(t, clients, names, v1.RouteSpec{
+	if _, err := v1test.PatchServiceRouteSpec(t, clients, byoServiceNames, v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{
 			Tag:          "example-tag",
 			RevisionName: byoRevName,
@@ -121,7 +129,7 @@ func bYORevisionPostUpgrade(t *testing.T) {
 	}
 }
 
-func updateService(serviceName string, t *testing.T) {
+func updateServiceAndCheck(t *testing.T, serviceName, toImage, textBeforeUpdate, textAfterUpdate string) {
 	t.Helper()
 	clients := e2e.Setup(t)
 	names := test.ResourceNames{
@@ -140,10 +148,10 @@ func updateService(serviceName string, t *testing.T) {
 	routeURL := svc.Status.URL.URL()
 
 	t.Log("Check that we can hit the old service and get the old response.")
-	assertServiceResourcesUpdated(t, clients, names, routeURL, test.PizzaPlanetText1)
+	assertServiceResourcesUpdated(t, clients, names, routeURL, textBeforeUpdate)
 
 	t.Log("Updating the Service to use a different image")
-	newImage := ptest.ImagePath(test.PizzaPlanet2)
+	newImage := ptest.ImagePath(toImage)
 	if _, err := v1test.PatchService(t, clients, svc, rtesting.WithServiceImage(newImage)); err != nil {
 		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, newImage, err)
 	}
@@ -151,7 +159,7 @@ func updateService(serviceName string, t *testing.T) {
 	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
 	revisionName, err := v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, test.PizzaPlanet2, err)
+		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, toImage, err)
 	}
 	names.Revision = revisionName
 
@@ -159,13 +167,13 @@ func updateService(serviceName string, t *testing.T) {
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
 	}
-	assertServiceResourcesUpdated(t, clients, names, routeURL, test.PizzaPlanetText2)
+	assertServiceResourcesUpdated(t, clients, names, routeURL, textAfterUpdate)
 }
 
 // CreateNewServicePostUpgradeTest verifies creating a new service after upgrade.
 func CreateNewServicePostUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("CreateNewServicePostUpgradeTest", func(c pkgupgrade.Context) {
-		createNewService(postUpgradeServiceName, c.T)
+		createNewService("pizzaplanet-post-upgrade-service", c.T)
 	})
 }
 
@@ -180,9 +188,10 @@ func InitialScalePostUpgradeTest() pkgupgrade.Operation {
 func initialScalePostUpgrade(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
+	test.EnsureTearDown(t, clients, &initialScaleServiceNames)
 
-	t.Logf("Getting service %q", initialScaleServiceName)
-	svc, err := clients.ServingClient.Services.Get(context.Background(), initialScaleServiceName, metav1.GetOptions{})
+	t.Logf("Getting service %q", initialScaleServiceNames.Service)
+	svc, err := clients.ServingClient.Services.Get(context.Background(), initialScaleServiceNames.Service, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Failed to get Service:", err)
 	}

--- a/test/upgrade/preupgrade.go
+++ b/test/upgrade/preupgrade.go
@@ -49,12 +49,7 @@ func servicePreUpgrade(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
 
-	names := test.ResourceNames{
-		Service: serviceName,
-		Image:   test.PizzaPlanet1,
-	}
-
-	resources, err := v1test.CreateServiceReady(t, clients, &names,
+	resources, err := v1test.CreateServiceReady(t, clients, &upgradeServiceNames,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.MinScaleAnnotationKey: "1", //make sure we don't scale to zero during the test
 		}),
@@ -63,7 +58,7 @@ func servicePreUpgrade(t *testing.T) {
 		t.Fatal("Failed to create Service:", err)
 	}
 	url := resources.Service.Status.URL.URL()
-	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
+	assertServiceResourcesUpdated(t, clients, upgradeServiceNames, url, test.PizzaPlanetText1)
 }
 
 // ServicePreUpgradeAndScaleToZeroTest creates a new service before
@@ -78,12 +73,7 @@ func servicePreUpgradeAndScaleToZero(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
 
-	names := test.ResourceNames{
-		Service: scaleToZeroServiceName,
-		Image:   test.PizzaPlanet1,
-	}
-
-	resources, err := v1test.CreateServiceReady(t, clients, &names,
+	resources, err := v1test.CreateServiceReady(t, clients, &scaleToZeroServiceNames,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: autoscaling.WindowMin.String(), //make sure we scale to zero quickly
 		}),
@@ -92,7 +82,7 @@ func servicePreUpgradeAndScaleToZero(t *testing.T) {
 		t.Fatal("Failed to create Service:", err)
 	}
 	url := resources.Service.Status.URL.URL()
-	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
+	assertServiceResourcesUpdated(t, clients, scaleToZeroServiceNames, url, test.PizzaPlanetText1)
 
 	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
 		t.Fatal("Could not scale to zero:", err)
@@ -110,12 +100,8 @@ func BYORevisionPreUpgradeTest() pkgupgrade.Operation {
 func bYORevisionPreUpgrade(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
-	names := test.ResourceNames{
-		Service: byoServiceName,
-		Image:   test.PizzaPlanet1,
-	}
 
-	if _, err := v1test.CreateServiceReady(t, clients, &names,
+	if _, err := v1test.CreateServiceReady(t, clients, &byoServiceNames,
 		rtesting.WithBYORevisionName(byoRevName)); err != nil {
 		t.Fatal("Failed to create Service:", err)
 	}
@@ -132,12 +118,8 @@ func InitialScalePreUpgradeTest() pkgupgrade.Operation {
 func initialScalePreUpgrade(t *testing.T) {
 	t.Parallel()
 	clients := e2e.Setup(t)
-	names := test.ResourceNames{
-		Service: initialScaleServiceName,
-		Image:   test.PizzaPlanet1,
-	}
 
-	resources, err := v1test.CreateServiceReady(t, clients, &names)
+	resources, err := v1test.CreateServiceReady(t, clients, &initialScaleServiceNames)
 	if err != nil {
 		t.Fatal("Failed to create Service:", err)
 	}

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -35,15 +35,29 @@ import (
 )
 
 const (
+	byoServiceName = "byo-revision-name-upgrade-test"
+	byoRevName     = byoServiceName + "-" + "rev1"
+)
+
+var (
 	// These service names need to be stable, since we use them across
-	// multiple "go test" invocations.
-	serviceName              = "pizzaplanet-upgrade-service"
-	postUpgradeServiceName   = "pizzaplanet-post-upgrade-service"
-	postDowngradeServiceName = "pizzaplanet-post-downgrade-service"
-	scaleToZeroServiceName   = "scale-to-zero-upgrade-service"
-	byoServiceName           = "byo-revision-name-upgrade-test"
-	byoRevName               = byoServiceName + "-" + "rev1"
-	initialScaleServiceName  = "init-scale-service"
+	// multiple tests.
+	upgradeServiceNames = test.ResourceNames{
+		Service: "pizzaplanet-upgrade-service",
+		Image:   test.PizzaPlanet1,
+	}
+	scaleToZeroServiceNames = test.ResourceNames{
+		Service: "scale-to-zero-upgrade-service",
+		Image:   test.PizzaPlanet1,
+	}
+	byoServiceNames = test.ResourceNames{
+		Service: byoServiceName,
+		Image:   test.PizzaPlanet1,
+	}
+	initialScaleServiceNames = test.ResourceNames{
+		Service: "init-scale-service",
+		Image:   test.PizzaPlanet1,
+	}
 )
 
 // Shamelessly cribbed from conformance/service_test.
@@ -70,6 +84,7 @@ func createNewService(serviceName string, t *testing.T) {
 		Service: serviceName,
 		Image:   test.PizzaPlanet1,
 	}
+	test.EnsureTearDown(t, clients, &names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {


### PR DESCRIPTION
Backport of upstream PR: https://github.com/knative/serving/pull/12395
https://issues.redhat.com/browse/SRVKS-868

* Ensure service cleanup in upgrade tests
* clean the services within Golang test, either in post-upgrade or
post-downgrade test if it is executed
* re-use code from updateService function in servicePostDowngrade test
* Fix service names in ScaleToZero post upgrade test

