### PR TITLE
[SRVKS-895] Fix features cm for pvc support

### DIFF
--- a/openshift/release/knative-serving-knative-v1.1.2.yaml
+++ b/openshift/release/knative-serving-knative-v1.1.2.yaml
@@ -4083,7 +4083,7 @@ metadata:
     app.kubernetes.io/version: "v1.1.2"
     serving.knative.dev/release: "v1.1.2"
   annotations:
-    knative.dev/example-checksum: "2897f625"
+    knative.dev/example-checksum: "d9e300ba"
 data:
   _example: |-
     ################################
@@ -4209,6 +4209,16 @@ data:
     # 1. Enabled: enabling init containers support
     # 2. Disabled: disabling init containers support
     kubernetes.podspec-init-containers: "disabled"
+
+    # Controls whether persistent volume claim support is enabled or not.
+    # 1. Enabled: enabling persistent volume claim support
+    # 2. Disabled: disabling persistent volume claim support
+    kubernetes.podspec-persistent-volume-claim: "disabled"
+
+    # Controls whether write access for persistent volumes is enabled or not.
+    # 1. Enabled: enabling write access for persistent volumes
+    # 2. Disabled: disabling write access for persistent volumes
+    kubernetes.podspec-persistent-volume-write: "disabled"
 ---
 # Copyright 2018 The Knative Authors
 #


### PR DESCRIPTION
Detected this in https://github.com/openshift-knative/serverless-operator/pull/1460. The features cm [misses](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/1460/pull-ci-openshift-knative-serverless-operator-main-4.10-upstream-e2e-mesh-aws-ocp-410/1509483665623617536/artifacts/upstream-e2e-mesh-aws-ocp-410/serverless-e2e/artifacts/gather-knative/quay-io-openshift-knative-must-gather-sha256-51049ace7b41db7499a225b27bf11492e419245a3c49581020c184d6c816d410/knative-serving/configmaps/describe.log) the new attributes.
Cm needs to be equal to https://github.com/openshift/knative-serving/blob/release-v1.1.2/config/core/configmaps/features.yaml

Generated with `./openshift/release/generate-release.sh knative-v1.1.2`. 