### PR TITLE
[RELEASE 1.2.0] bump resolve label to 1.2.0

### DIFF
--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -19,8 +19,8 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -44,8 +44,8 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -57,8 +57,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
@@ -97,8 +97,8 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -114,8 +114,8 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -131,8 +131,8 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -159,8 +159,8 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -213,8 +213,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
@@ -253,8 +253,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,8 +262,8 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -276,8 +276,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -294,8 +294,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -325,7 +325,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -378,8 +378,8 @@ metadata:
   name: certificates.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -437,8 +437,8 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1144,8 +1144,8 @@ metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1194,8 +1194,8 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1464,8 +1464,8 @@ metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1524,8 +1524,8 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1647,8 +1647,8 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1807,8 +1807,8 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2522,8 +2522,8 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2696,8 +2696,8 @@ metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2767,8 +2767,8 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3541,8 +3541,8 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -3570,8 +3570,8 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "16af78ce"
 data:
@@ -3781,8 +3781,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "a0feb4c6"
 data:
@@ -3924,8 +3924,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:
@@ -4027,8 +4027,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -4092,8 +4092,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "d9e300ba"
 data:
@@ -4254,8 +4254,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "51b4d68a"
 data:
@@ -4354,8 +4354,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -4414,8 +4414,8 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
   annotations:
     knative.dev/example-checksum: "be93ff10"
@@ -4493,8 +4493,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "6e2033e0"
 data:
@@ -4668,8 +4668,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:
@@ -4776,8 +4776,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -4833,8 +4833,8 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4862,8 +4862,8 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4891,9 +4891,9 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -4908,8 +4908,8 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -5004,9 +5004,9 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     app: activator
@@ -5048,8 +5048,8 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   replicas: 1
   selector:
@@ -5063,8 +5063,8 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5151,8 +5151,8 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -5192,8 +5192,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -5206,8 +5206,8 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5275,8 +5275,8 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -5313,8 +5313,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -5327,8 +5327,8 @@ spec:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5406,8 +5406,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -5422,8 +5422,8 @@ spec:
         role: domainmapping-webhook
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5518,8 +5518,8 @@ metadata:
     role: domainmapping-webhook
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5559,8 +5559,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5586,8 +5586,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minAvailable: 80%
   selector:
@@ -5614,9 +5614,9 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -5630,9 +5630,9 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v1.1.2"
+        serving.knative.dev/release: "v1.2.0"
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/name: knative-serving
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -5728,9 +5728,9 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -5770,8 +5770,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5808,8 +5808,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5863,8 +5863,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5910,8 +5910,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -5935,8 +5935,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5982,8 +5982,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6039,8 +6039,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 # The data is populated at install time.
 ---
 # Copyright 2019 The Knative Authors
@@ -6066,8 +6066,8 @@ metadata:
     autoscaling.knative.dev/autoscaler-provider: hpa
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -6080,8 +6080,8 @@ spec:
         app: autoscaler-hpa
         app.kubernetes.io/component: autoscaler-hpa
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -6146,8 +6146,8 @@ metadata:
     autoscaling.knative.dev/autoscaler-provider: hpa
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: autoscaler-hpa
   namespace: knative-serving
 spec:

--- a/openshift/release/knative-serving-knative-1.2.0.yaml
+++ b/openshift/release/knative-serving-knative-1.2.0.yaml
@@ -19,8 +19,8 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 ---
 # Copyright 2019 The Knative Authors
 #
@@ -44,8 +44,8 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -57,8 +57,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
@@ -97,8 +97,8 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -114,8 +114,8 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -131,8 +131,8 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -159,8 +159,8 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -213,8 +213,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
@@ -253,8 +253,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,8 +262,8 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -276,8 +276,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -294,8 +294,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -325,7 +325,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -378,8 +378,8 @@ metadata:
   name: certificates.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -437,8 +437,8 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1144,8 +1144,8 @@ metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1194,8 +1194,8 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1464,8 +1464,8 @@ metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1524,8 +1524,8 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1647,8 +1647,8 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1807,8 +1807,8 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2522,8 +2522,8 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2696,8 +2696,8 @@ metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2767,8 +2767,8 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3541,8 +3541,8 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -3570,8 +3570,8 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "16af78ce"
 data:
@@ -3781,8 +3781,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "a0feb4c6"
 data:
@@ -3924,8 +3924,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:
@@ -4027,8 +4027,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -4092,8 +4092,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "d9e300ba"
 data:
@@ -4254,8 +4254,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "51b4d68a"
 data:
@@ -4354,8 +4354,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -4414,8 +4414,8 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.1.2"
-    app.kubernetes.io/version: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
   annotations:
     knative.dev/example-checksum: "be93ff10"
@@ -4493,8 +4493,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "6e2033e0"
 data:
@@ -4668,8 +4668,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:
@@ -4776,8 +4776,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -4833,8 +4833,8 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4862,8 +4862,8 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4891,9 +4891,9 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -4908,8 +4908,8 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -5004,9 +5004,9 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     app: activator
@@ -5048,8 +5048,8 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   replicas: 1
   selector:
@@ -5063,8 +5063,8 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5151,8 +5151,8 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -5192,8 +5192,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -5206,8 +5206,8 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5275,8 +5275,8 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -5313,8 +5313,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -5327,8 +5327,8 @@ spec:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5406,8 +5406,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -5422,8 +5422,8 @@ spec:
         role: domainmapping-webhook
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -5518,8 +5518,8 @@ metadata:
     role: domainmapping-webhook
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5559,8 +5559,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5586,8 +5586,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   minAvailable: 80%
   selector:
@@ -5614,9 +5614,9 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -5630,9 +5630,9 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v1.1.2"
+        serving.knative.dev/release: "v1.2.0"
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
         app.kubernetes.io/name: knative-serving
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -5728,9 +5728,9 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v1.1.2"
+    serving.knative.dev/release: "v1.2.0"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -5770,8 +5770,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5808,8 +5808,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5863,8 +5863,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5910,8 +5910,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -5935,8 +5935,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -5982,8 +5982,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6039,8 +6039,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 # The data is populated at install time.
 ---
 # Copyright 2019 The Knative Authors
@@ -6066,8 +6066,8 @@ metadata:
     autoscaling.knative.dev/autoscaler-provider: hpa
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
 spec:
   selector:
     matchLabels:
@@ -6080,8 +6080,8 @@ spec:
         app: autoscaler-hpa
         app.kubernetes.io/component: autoscaler-hpa
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.1.2"
-        serving.knative.dev/release: "v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -6146,8 +6146,8 @@ metadata:
     autoscaling.knative.dev/autoscaler-provider: hpa
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.1.2"
-    serving.knative.dev/release: "v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    serving.knative.dev/release: "v1.2.0"
   name: autoscaler-hpa
   namespace: knative-serving
 spec:

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -21,7 +21,7 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v1.1.2\"+" \
-      -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \"v1.1.2\"+" \
+  sed -e "s+serving.knative.dev/release: devel+serving.knative.dev/release: \"v1.2.0\"+" \
+      -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \"v1.2.0\"+" \
       "$file" >> "$to"
 }


### PR DESCRIPTION
Now that [Knative serving, operator is on 1.2.0 ](https://github.com/openshift-knative/serverless-operator/pull/1501)we need to fix this so tests can run. When it passes will file one against main.