### PR TITLE
[RELEASE-1.3] Poke CI

### DIFF
--- a/ci
+++ b/ci
@@ -1,0 +1,1 @@
+Wed Jun  1 04:30:55 PM EEST 2022


### PR DESCRIPTION
* registry.ci.openshift.org/openshift/knative-v1.3.2:knative-serving-queue does not exist
* Required from here: https://github.com/openshift-knative/serverless-operator/pull/1598. We never had a PR on this branch and images are only built after a PR is merged. See discussion [here](https://coreos.slack.com/archives/CD87JDUB0/p1654083274757569).
* First we need to merge:https://github.com/openshift/release/pull/29062
