### PR TITLE
Use ubi8-minimal in ko builds

### DIFF
--- a/openshift/patches/100-ko-baseimage.patch
+++ b/openshift/patches/100-ko-baseimage.patch
@@ -1,0 +1,11 @@
+diff --git a/.ko.yaml b/.ko.yaml
+index 14afa53a5..bceaa1320 100644
+--- a/.ko.yaml
++++ b/.ko.yaml
+@@ -1,4 +1,5 @@
+ # Use :nonroot base image for all containers
+-defaultBaseImage: gcr.io/distroless/static:nonroot
++defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:latest
+ baseImageOverrides:
++  knative.dev/serving/test/test_images/runtime: gcr.io/distroless/static:nonroot
+   knative.dev/serving/vendor/github.com/tsenart/vegeta/v12: ubuntu:latest


### PR DESCRIPTION
This more closely matches Prow CI builds, and provides a shell and package manager for debugging purposes.
