### PR TITLE
[MAIN] Fix build image dockerfile for go 1.18

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,7 +7,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl httpd-tools
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
See https://github.com/openshift/knative-serving/pull/1180#issuecomment-1195126726
Tested locally:
```
Sending build context to Docker daemon  84.89MB
Step 1/5 : FROM registry.ci.openshift.org/openshift/release:golang-1.18
 ---> 7668105daf96
Step 2/5 : ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 ---> Using cache
 ---> 8197b37fecd4
Step 3/5 : RUN yum install -y kubectl httpd-tools
 ---> Using cache
 ---> 7c28d49c6503
Step 4/5 : RUN go install github.com/mikefarah/yq/v4@latest
 ---> Running in 4ff8c258b559
go: github.com/mikefarah/yq/v4@latest: cannot query module due to -mod=vendor
The command '/bin/sh -c go install github.com/mikefarah/yq/v4@latest' returned a non-zero code: 1
[stavros@easy serving]$ nano openshift/ci-operator/build-image/Dockerfile 
[stavros@easy serving]$ docker build -t bimage . -f openshift/ci-operator/build-image/Dockerfile 
Sending build context to Docker daemon  84.89MB
Step 1/5 : FROM registry.ci.openshift.org/openshift/release:golang-1.18
 ---> 7668105daf96
Step 2/5 : ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 ---> Using cache
 ---> 8197b37fecd4
Step 3/5 : RUN yum install -y kubectl httpd-tools
 ---> Using cache
 ---> 7c28d49c6503
Step 4/5 : RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 ---> Running in 033869a73dee
go: downloading github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37
go: downloading github.com/mikefarah/yq v2.4.0+incompatible
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/kylelemons/godebug v1.1.0
go: downloading gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
go: downloading github.com/spf13/cobra v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: downloading github.com/fatih/color v1.9.0
go: downloading github.com/goccy/go-yaml v1.8.1
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/mattn/go-isatty v0.0.12
go: downloading github.com/mattn/go-colorable v0.1.7
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
Removing intermediate container 033869a73dee
 ---> 592b458e663c
Step 5/5 : RUN chmod g+rw /etc/passwd
 ---> Running in 143307b18d1a
Removing intermediate container 143307b18d1a
 ---> 390ff5f59b6c
Successfully built 390ff5f59b6c
Successfully tagged bimage:latest
```