### PR TITLE
[RELEASE-1.4] Fix pdb version 

### DIFF
--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -4873,7 +4873,7 @@ spec:
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want
 # a slow rollout of the new versions and slow migration during node upgrades.
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: activator-pdb
@@ -5560,7 +5560,7 @@ spec:
           averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-pdb

--- a/openshift/release/manifest-patches/003-serving-pdb.patch
+++ b/openshift/release/manifest-patches/003-serving-pdb.patch
@@ -2,6 +2,24 @@ diff --git a/openshift/release/artifacts/2-serving-core.yaml b/openshift/release
 index 1616f3311..ecc27ee95 100644
 --- a/openshift/release/artifacts/2-serving-core.yaml
 +++ b/openshift/release/artifacts/2-serving-core.yaml
+@@ -4873,7 +4873,7 @@ spec:
+ # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
+ # Given the subsetting and that the activators are partially stateful systems, we want
+ # a slow rollout of the new versions and slow migration during node upgrades.
+-apiVersion: policy/v1
++apiVersion: policy/v1beta1
+ kind: PodDisruptionBudget
+ metadata:
+   name: activator-pdb
+@@ -5560,7 +5560,7 @@ spec:
+           averageUtilization: 100
+ ---
+ # Webhook PDB.
+-apiVersion: policy/v1
++apiVersion: policy/v1beta1
+ kind: PodDisruptionBudget
+ metadata:
+   name: webhook-pdb
 @@ -4883,7 +4883,7 @@ metadata:
      app.kubernetes.io/name: knative-serving
      app.kubernetes.io/version: "1.4.0"


### PR DESCRIPTION
Missed the version downgrade for pdb [here](https://github.com/openshift-knative/serverless-operator/commit/a352d77702f325a021e229c9f583c94a3345feeb#diff-d472280895c150a44c791dd7a9e232b1667f3bdee109170fbf0de8821680561f). Failures [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serverless-operator-main-4.6-upgrade-tests-aws-ocp-46-continuous/1552806242353680384).
For 4.6 (K8s 1.19) we need the beta. Note that the beta will no long be available in 1.25+.