### PR TITLE
[RELEASE-1.5] Fix pdb version

### DIFF
--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -4884,7 +4884,7 @@ spec:
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want
 # a slow rollout of the new versions and slow migration during node upgrades.
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: activator-pdb
@@ -5571,7 +5571,7 @@ spec:
           averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-pdb

--- a/openshift/release/manifest-patches/003-serving-pdb.patch
+++ b/openshift/release/manifest-patches/003-serving-pdb.patch
@@ -2,6 +2,24 @@ diff --git a/openshift/release/artifacts/2-serving-core.yaml b/openshift/release
 index 1616f3311..ecc27ee95 100644
 --- a/openshift/release/artifacts/2-serving-core.yaml
 +++ b/openshift/release/artifacts/2-serving-core.yaml
+@@ -4873,7 +4873,7 @@ spec:
+ # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
+ # Given the subsetting and that the activators are partially stateful systems, we want
+ # a slow rollout of the new versions and slow migration during node upgrades.
+-apiVersion: policy/v1
++apiVersion: policy/v1beta1
+ kind: PodDisruptionBudget
+ metadata:
+   name: activator-pdb
+@@ -5560,7 +5560,7 @@ spec:
+           averageUtilization: 100
+ ---
+ # Webhook PDB.
+-apiVersion: policy/v1
++apiVersion: policy/v1beta1
+ kind: PodDisruptionBudget
+ metadata:
+   name: webhook-pdb
 @@ -4883,7 +4883,7 @@ metadata:
      app.kubernetes.io/name: knative-serving
      app.kubernetes.io/version: "1.5.0"


### PR DESCRIPTION
Similar to https://github.com/openshift/knative-serving/pull/1194.
Not sure if we will target 4.6 with 1.5 but let's see. beta version will be removed with K8s 1.25+, probably with OCP 4.12. 
4.11 is 1.24. Are we going to remove 4.6 once 4.11 is out?
/assign @nak3 