### PR TITLE
Download nightly build manifest when version is CI

### DIFF
--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -35,6 +35,9 @@ function download_serving {
     target_file="$target_dir/$index-$file"
 
     url="https://github.com/knative/$component/releases/download/knative-$release_suffix/$file"
+    if [[ "$version" == "ci" ]]; then
+      url="https://storage.googleapis.com/knative-nightly/$component/latest/$file"
+    fi
     wget --no-check-certificate "$url" -O "$target_file"
   done
 }


### PR DESCRIPTION
https://github.com/openshift/knative-serving/pull/1191 changed to download the manifest from `https://github.com/knative/$component/releases/download/knative-$release_suffix/$file` but the nightly build does not exist in the URL.

This patch fixes it.