### PR TITLE
[RELEASE-1.25] Fix checksum for configmap networking

### DIFF
--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -4509,7 +4509,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: "1.5.0"
   annotations:
-    knative.dev/example-checksum: "d0b91f80"
+    knative.dev/example-checksum: "73d96d1b"
 data:
   _example: |
     ################################


### PR DESCRIPTION
The PR here https://github.com/openshift/knative-serving/pull/1236, downloads and patches the release manifests and changes the networking configmap among others. The checksum was not changed however which leads to a failure at the S-O side https://github.com/openshift-knative/serverless-operator/pull/1732#issuecomment-1257645432.