### PR TITLE
[MAIN] Workaround for activator's websocket disconnection

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -240,6 +240,10 @@ EOF
     # Deploy certificates for testing TLS with cluster-local gateway
     timeout 600 '[[ $(oc get ns $SERVING_INGRESS_NAMESPACE -oname | wc -l) == 0 ]]' || return 1
     yq read --doc 1 ./test/config/tls/cert-secret.yaml | yq write - metadata.namespace ${SERVING_INGRESS_NAMESPACE} | oc apply -f -
+    # Make sure that  autoscaler is up and activator can connect
+    # TODO:  This should be removed once we figure out why autoscaler leader election takes too long
+    # some times
+    sleep 60
     echo "Restart activator to mount the certificates"
     oc delete pod -n ${SERVING_NAMESPACE} -l app=activator
     oc wait --timeout=60s --for=condition=Available deployment  -n ${SERVING_NAMESPACE} activator


### PR DESCRIPTION
On the 4.11 tls job we see the following ([run logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_knative-serving/1253/pull-ci-openshift-knative-serving-release-next-411-e2e-aws-ocp-tls-411/1574340796381925376/artifacts/e2e-aws-ocp-tls-411/gather-extra/artifacts/pods/knative-serving_activator-8457d4b5cc-psgk7_activator.log)):

> autoscaler:
{"severity":"INFO","timestamp":"2022-09-26T10:57:45.798603761Z","logger":"autoscaler","caller":"leaderelection/context.go:158","message":"\"autoscaler-5f7b978454-z6cx8_10.131.0.24\" has started leading \"autoscaler-bucket-00-of-01\"","commit":"2158680"}
E0926 10:57:45.801421       1 leaderelection.go:334] error initially creating leader election record: leases.coordination.k8s.io "autoscaler-bucket-00-of-01" already exists
{"severity":"INFO","timestamp":"2022-09-26T10:57:45.813593953Z","logger":"autoscaler","caller":"statforwarder/leases.go:194","message":"Created Service for Lease knative-serving/autoscaler-bucket-00-of-01","commit":"2158680"}
{"severity":"INFO","timestamp":"2022-09-26T10:57:45.820900013Z","logger":"autoscaler","caller":"statforwarder/leases.go:200","message":"Created Endpoints for Lease knative-serving/autoscaler-bucket-00-of-01","commit":"2158680"}
I0926 10:57:56.977958       1 leaderelection.go:258] successfully acquired lease knative-serving/autoscaler-bucket-00-of-0

> activator:
{"severity":"ERROR","timestamp":"2022-09-26T10:57:50.848193139Z","logger":"activator","caller":"websocket/connection.go:144","message":"Websocket connection could not be established","commit":"2158680","knative.dev/controller":"activator","knative.dev/pod":"activator-8457d4b5cc-psgk7","error":"dial tcp 172.30.34.227:8080: connect: connection refused","stacktrace":"knative.dev/pkg/websocket.NewDurableConnection.func1\n\t/go/src/knative.dev/serving/vendor/knative.dev/pkg/websocket/connection.go:144\nknative.dev/pkg/websocket.

For some reason after the pods are deleted activator waits for autoscaler and never has the chance to connect. By making sure autoscaler is up we can safely do the delete to avoid this situation. This is not a fix and this needs to be discussed upstream as their an error in the lease process. [Slack discussion](https://coreos.slack.com/archives/CF5ANN61F/p1664201523995109).

cc @mgencur @maschmid this requires a test case as discussed [here](https://coreos.slack.com/archives/CF5ANN61F/p1664287236736679?thread_ts=1664201523.995109&cid=CF5ANN61F), because user may add a new certificate, delete pods and may hit that too.