### PR TITLE
[RELEASE-1.5] [BACKPORT] Fix sc for psp compliance

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -84,7 +84,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -85,8 +85,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -84,7 +84,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
 
         ports:
         - name: metrics

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -93,7 +93,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -94,8 +94,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
+
 
         ports:
         - name: metrics

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -93,7 +93,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
 
 
         ports:

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -85,7 +85,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -86,8 +86,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -85,7 +85,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -81,7 +81,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -81,7 +81,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -82,8 +82,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -89,7 +89,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -90,8 +90,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -89,7 +89,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
 
         ports:
         - name: metrics

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -90,7 +90,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -90,7 +90,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
 
         ports:
         - name: metrics

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -91,8 +91,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -83,8 +83,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -82,7 +82,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -64,8 +64,7 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault
+
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -61,6 +61,11 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -61,5 +61,3 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -58,3 +58,8 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -4978,7 +4978,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090
@@ -5138,7 +5138,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090
@@ -5268,7 +5268,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090
@@ -5376,7 +5376,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090
@@ -5470,7 +5470,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090
@@ -5669,7 +5669,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -53,3 +53,6 @@ git apply "${manifest_path}/003-serving-pdb.patch"
 
 # Add internal-tls patch. The backport will conflict with the downloaded manifest.
 git apply "${manifest_path}/004-internal-tls.patch"
+
+# Add psp patch.
+git apply "${manifest_path}/005-psp.patch"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -4974,7 +4974,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5141,7 +5141,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5278,7 +5278,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5392,7 +5392,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5491,7 +5491,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5697,7 +5697,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics

--- a/openshift/release/knative-serving-knative-v1.5.0.yaml
+++ b/openshift/release/knative-serving-knative-v1.5.0.yaml
@@ -4980,7 +4980,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5147,7 +5147,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5284,7 +5284,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5398,7 +5398,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5497,7 +5497,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics
@@ -5703,7 +5703,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+              - ALL
 
         ports:
         - name: metrics

--- a/openshift/release/manifest-patches/005-psp.patch
+++ b/openshift/release/manifest-patches/005-psp.patch
@@ -1,0 +1,58 @@
+diff --git a/openshift/release/artifacts/2-serving-core.yaml b/openshift/release/artifacts/2-serving-core.yaml
+index abe895e01..88ff800ce 100644
+--- a/openshift/release/artifacts/2-serving-core.yaml
++++ b/openshift/release/artifacts/2-serving-core.yaml
+@@ -4978,7 +4978,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090
+@@ -5138,7 +5138,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090
+@@ -5268,7 +5268,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090
+@@ -5376,7 +5376,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090
+@@ -5470,7 +5470,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090
+@@ -5669,7 +5669,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090

--- a/third_party/cert-manager-latest/cert-manager.yaml
+++ b/third_party/cert-manager-latest/cert-manager.yaml
@@ -5160,6 +5160,14 @@ spec:
                 fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+
       nodeSelector:
         kubernetes.io/os: linux
 ---
@@ -5213,6 +5221,13 @@ spec:
             protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -5288,6 +5303,13 @@ spec:
             failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/third_party/cert-manager-latest/cert-manager.yaml
+++ b/third_party/cert-manager-latest/cert-manager.yaml
@@ -5165,8 +5165,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
 
       nodeSelector:
         kubernetes.io/os: linux
@@ -5226,8 +5224,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -5308,8 +5304,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/third_party/cert-manager-latest/net-certmanager.yaml
+++ b/third_party/cert-manager-latest/net-certmanager.yaml
@@ -217,8 +217,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -323,8 +321,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090

--- a/third_party/cert-manager-latest/net-certmanager.yaml
+++ b/third_party/cert-manager-latest/net-certmanager.yaml
@@ -216,7 +216,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -320,7 +322,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090

--- a/third_party/contour-latest/contour.yaml
+++ b/third_party/contour-latest/contour.yaml
@@ -4240,8 +4240,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
       restartPolicy: Never
       serviceAccountName: contour-certgen
       securityContext:
@@ -4383,8 +4381,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       securityContext:

--- a/third_party/contour-latest/contour.yaml
+++ b/third_party/contour-latest/contour.yaml
@@ -4235,6 +4235,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       restartPolicy: Never
       serviceAccountName: contour-certgen
       securityContext:
@@ -4372,6 +4379,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       securityContext:

--- a/third_party/contour-latest/net-contour.yaml
+++ b/third_party/contour-latest/net-contour.yaml
@@ -141,6 +141,8 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 

--- a/third_party/contour-latest/net-contour.yaml
+++ b/third_party/contour-latest/net-contour.yaml
@@ -142,7 +142,5 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
 ---
 

--- a/third_party/gateway-api-latest/net-gateway-api.yaml
+++ b/third_party/gateway-api-latest/net-gateway-api.yaml
@@ -2425,6 +2425,8 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 
 ---

--- a/third_party/gateway-api-latest/net-gateway-api.yaml
+++ b/third_party/gateway-api-latest/net-gateway-api.yaml
@@ -2426,7 +2426,5 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
 
 ---


### PR DESCRIPTION
* Backport of https://github.com/knative/serving/pull/13327
* Drops seccomp profile in 13327 as not all OCP versions support it. We will add it on demand at the S-O side.
* Propagates changes in 13327 to ci and release manifests for 1.5