### PR TITLE
Deprecate openshift/knative-serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repository is deprecated. Use [`https://github.com/openshift-knative/serving`](https://github.com/openshift-knative/serving)
+
 # Openshift Knative Serving
 
 This repository holds Openshift's fork of


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVKS-964

Should be merged before https://github.com/openshift/release/pull/33058