### PR TITLE
Fix 1.25 issues

### DIFF
--- a/openshift/patches/008-remove-seccomp-queue.patch
+++ b/openshift/patches/008-remove-seccomp-queue.patch
@@ -1,0 +1,14 @@
+diff --git a/pkg/reconciler/revision/resources/queue.go b/pkg/reconciler/revision/resources/queue.go
+index 29ac1db50..fc4178433 100644
+--- a/pkg/reconciler/revision/resources/queue.go
++++ b/pkg/reconciler/revision/resources/queue.go
+@@ -87,9 +87,6 @@ var (
+ 		Capabilities: &corev1.Capabilities{
+ 			Drop: []corev1.Capability{"ALL"},
+ 		},
+-		SeccompProfile: &corev1.SeccompProfile{
+-			Type: corev1.SeccompProfileTypeRuntimeDefault,
+-		},
+ 	}
+ )
+ 

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -24,6 +24,9 @@ git commit -am ":fire: Apply carried patches."
 # Revert the autoscaling API version change.
 git revert 974d19d03644dff46b097a15efb4d3d7167765ad
 
+# Revert the autoscaling API version change in webhook resource.
+git revert a6a18b857be4f9e03a5bc4e196ea8450ff68828e
+
 make generate-dockerfiles
 make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile


### PR DESCRIPTION
- Reverts the commit https://github.com/knative/serving/pull/13411 to avoid autoscaling v2 in webhook resource
- Removes the seccompProfile from queue proxy as on OCP it makes container run asAny and not container user thus breaking conformance tests, check [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_knative-serving/1286/pull-ci-openshift-knative-serving-release-next-411-e2e-aws-ocp-411/1583021419543924736).
- Tested in #1286 