### PR TITLE
[RELEASE-1.6] Reset drainer to avoid deadlock when liveness probe fails

### DIFF
--- a/test/test_images/readiness/service.yaml
+++ b/test/test_images/readiness/service.yaml
@@ -8,3 +8,8 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/readiness
+      livenessProbe:
+        httpGet:
+          path: /healthz
+        periodSeconds: 1
+        failureThreshold: 1


### PR DESCRIPTION
This is a backport of https://github.com/openshift/knative-serving/pull/1252.

/cc @skonto 