### PR TITLE
[RELEASE-v1.8] Revert "upgrade k8s autoscaling to v2 (#13337)"

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: activator

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -22,7 +22,7 @@ import (
 	networkingclient "knative.dev/networking/pkg/client/injection/client"
 	sksinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	hpainformer "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2/horizontalpodautoscaler"
+	hpainformer "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler"
 	"knative.dev/pkg/logging"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	autoscalingv2listers "k8s.io/client-go/listers/autoscaling/v2"
+	autoscalingv2beta2listers "k8s.io/client-go/listers/autoscaling/v2beta2"
 	nv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
@@ -42,7 +42,7 @@ type Reconciler struct {
 	*areconciler.Base
 
 	kubeClient kubernetes.Interface
-	hpaLister  autoscalingv2listers.HorizontalPodAutoscalerLister
+	hpaLister  autoscalingv2beta2listers.HorizontalPodAutoscalerLister
 }
 
 // Check that our Reconciler implements pareconciler.Interface
@@ -61,7 +61,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	hpa, err := c.hpaLister.HorizontalPodAutoscalers(pa.Namespace).Get(desiredHpa.Name)
 	if errors.IsNotFound(err) {
 		logger.Infof("Creating HPA %q", desiredHpa.Name)
-		if hpa, err = c.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(pa.Namespace).Create(ctx, desiredHpa, metav1.CreateOptions{}); err != nil {
+		if hpa, err = c.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(pa.Namespace).Create(ctx, desiredHpa, metav1.CreateOptions{}); err != nil {
 			pa.Status.MarkResourceFailedCreation("HorizontalPodAutoscaler", desiredHpa.Name)
 			return fmt.Errorf("failed to create HPA: %w", err)
 		}
@@ -74,7 +74,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	}
 	if !equality.Semantic.DeepEqual(desiredHpa.Spec, hpa.Spec) {
 		logger.Infof("Updating HPA %q", desiredHpa.Name)
-		if _, err := c.kubeClient.AutoscalingV2().HorizontalPodAutoscalers(pa.Namespace).Update(ctx, desiredHpa, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(pa.Namespace).Update(ctx, desiredHpa, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update HPA: %w", err)
 		}
 	}

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/serverlessservice/fake"
-	_ "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2/horizontalpodautoscaler/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	_ "knative.dev/pkg/metrics/testing"
 	_ "knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable/fake"
@@ -125,7 +125,7 @@ func TestControllerCanReconcile(t *testing.T) {
 		t.Error("Reconcile() =", err)
 	}
 
-	_, err = fakekubeclient.Get(ctx).AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Get(ctx, testRevision, metav1.GetOptions{})
+	_, err = fakekubeclient.Get(ctx).AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Get(ctx, testRevision, metav1.GetOptions{})
 	if err != nil {
 		t.Error("error getting hpa:", err)
 	}
@@ -479,9 +479,9 @@ func pa(namespace, name string, options ...PodAutoscalerOption) *autoscalingv1al
 	return pa
 }
 
-type hpaOption func(*autoscalingv2.HorizontalPodAutoscaler)
+type hpaOption func(*autoscalingv2beta2.HorizontalPodAutoscaler)
 
-func withHPAOwnersRemoved(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+func withHPAOwnersRemoved(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
 	hpa.OwnerReferences = nil
 }
 
@@ -491,12 +491,12 @@ func withScales(d, a int32) PodAutoscalerOption {
 	}
 }
 func withHPAScaleStatus(d, a int32) hpaOption {
-	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+	return func(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
 		hpa.Status.DesiredReplicas, hpa.Status.CurrentReplicas = d, a
 	}
 }
 
-func hpa(pa *autoscalingv1alpha1.PodAutoscaler, options ...hpaOption) *autoscalingv2.HorizontalPodAutoscaler {
+func hpa(pa *autoscalingv1alpha1.PodAutoscaler, options ...hpaOption) *autoscalingv2beta2.HorizontalPodAutoscaler {
 	h := resources.MakeHPA(pa, defaultConfig().Autoscaler)
 	for _, o := range options {
 		o(h)

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -19,7 +19,7 @@ package resources
 import (
 	"math"
 
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,12 +33,12 @@ import (
 )
 
 // MakeHPA creates an HPA resource from a PA resource.
-func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autoscalingv2.HorizontalPodAutoscaler {
+func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autoscalingv2beta2.HorizontalPodAutoscaler {
 	min, max := pa.ScaleBounds(config)
 	if max == 0 {
 		max = math.MaxInt32 // default to no limit
 	}
-	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+	hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pa.Name,
 			Namespace:       pa.Namespace,
@@ -46,8 +46,8 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 			Annotations:     pa.Annotations,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pa)},
 		},
-		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
 				APIVersion: pa.Spec.ScaleTargetRef.APIVersion,
 				Kind:       pa.Spec.ScaleTargetRef.Kind,
 				Name:       pa.Spec.ScaleTargetRef.Name,
@@ -62,12 +62,12 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 	if target, ok := pa.Target(); ok {
 		switch pa.Metric() {
 		case autoscaling.CPU:
-			hpa.Spec.Metrics = []autoscalingv2.MetricSpec{{
-				Type: autoscalingv2.ResourceMetricSourceType,
-				Resource: &autoscalingv2.ResourceMetricSource{
+			hpa.Spec.Metrics = []autoscalingv2beta2.MetricSpec{{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
 					Name: corev1.ResourceCPU,
-					Target: autoscalingv2.MetricTarget{
-						Type:               autoscalingv2.UtilizationMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:               autoscalingv2beta2.UtilizationMetricType,
 						AverageUtilization: ptr.Int32(int32(math.Ceil(target))),
 					},
 				},
@@ -75,12 +75,12 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 
 		case autoscaling.Memory:
 			memory := resource.NewQuantity(int64(target)*1024*1024, resource.BinarySI)
-			hpa.Spec.Metrics = []autoscalingv2.MetricSpec{{
-				Type: autoscalingv2.ResourceMetricSourceType,
-				Resource: &autoscalingv2.ResourceMetricSource{
+			hpa.Spec.Metrics = []autoscalingv2beta2.MetricSpec{{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
 					Name: corev1.ResourceMemory,
-					Target: autoscalingv2.MetricTarget{
-						Type:         autoscalingv2.AverageValueMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:         autoscalingv2beta2.AverageValueMetricType,
 						AverageValue: memory,
 					},
 				},
@@ -88,14 +88,14 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 		default:
 			if target, ok := pa.Target(); ok {
 				targetQuantity := resource.NewQuantity(int64(target), resource.DecimalSI)
-				hpa.Spec.Metrics = []autoscalingv2.MetricSpec{{
-					Type: autoscalingv2.PodsMetricSourceType,
-					Pods: &autoscalingv2.PodsMetricSource{
-						Metric: autoscalingv2.MetricIdentifier{
+				hpa.Spec.Metrics = []autoscalingv2beta2.MetricSpec{{
+					Type: autoscalingv2beta2.PodsMetricSourceType,
+					Pods: &autoscalingv2beta2.PodsMetricSource{
+						Metric: autoscalingv2beta2.MetricIdentifier{
 							Name: pa.Metric(),
 						},
-						Target: autoscalingv2.MetricTarget{
-							Type:         autoscalingv2.AverageValueMetricType,
+						Target: autoscalingv2beta2.MetricTarget{
+							Type:         autoscalingv2beta2.AverageValueMetricType,
 							AverageValue: targetQuantity,
 						},
 					},
@@ -106,11 +106,11 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 
 	if window, hasWindow := pa.Window(); hasWindow {
 		windowSeconds := int32(window.Seconds())
-		hpa.Spec.Behavior = &autoscalingv2.HorizontalPodAutoscalerBehavior{
-			ScaleDown: &autoscalingv2.HPAScalingRules{
+		hpa.Spec.Behavior = &autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
+			ScaleDown: &autoscalingv2beta2.HPAScalingRules{
 				StabilizationWindowSeconds: &windowSeconds,
 			},
-			ScaleUp: &autoscalingv2.HPAScalingRules{
+			ScaleUp: &autoscalingv2beta2.HPAScalingRules{
 				StabilizationWindowSeconds: &windowSeconds,
 			},
 		}

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -28,7 +28,7 @@ import (
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ func TestMakeHPA(t *testing.T) {
 	cases := []struct {
 		name string
 		pa   *autoscalingv1alpha1.PodAutoscaler
-		want *autoscalingv2.HorizontalPodAutoscaler
+		want *autoscalingv2beta2.HorizontalPodAutoscaler
 	}{{
 		name: "defaults",
 		pa:   pa(),
@@ -64,12 +64,12 @@ func TestMakeHPA(t *testing.T) {
 		want: hpa(
 			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.CPU),
 			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
-			withMetric(autoscalingv2.MetricSpec{
-				Type: autoscalingv2.ResourceMetricSourceType,
-				Resource: &autoscalingv2.ResourceMetricSource{
+			withMetric(autoscalingv2beta2.MetricSpec{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
 					Name: corev1.ResourceCPU,
-					Target: autoscalingv2.MetricTarget{
-						Type:               autoscalingv2.UtilizationMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:               autoscalingv2beta2.UtilizationMetricType,
 						AverageUtilization: ptr.Int32(50),
 					},
 				},
@@ -80,12 +80,12 @@ func TestMakeHPA(t *testing.T) {
 		want: hpa(
 			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Memory),
 			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
-			withMetric(autoscalingv2.MetricSpec{
-				Type: autoscalingv2.ResourceMetricSourceType,
-				Resource: &autoscalingv2.ResourceMetricSource{
+			withMetric(autoscalingv2beta2.MetricSpec{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
 					Name: corev1.ResourceMemory,
-					Target: autoscalingv2.MetricTarget{
-						Type:         autoscalingv2.AverageValueMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:         autoscalingv2beta2.AverageValueMetricType,
 						AverageValue: resource.NewQuantity(50*1024*1024, resource.BinarySI),
 					},
 				},
@@ -96,12 +96,12 @@ func TestMakeHPA(t *testing.T) {
 		want: hpa(
 			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.CPU),
 			withAnnotationValue(autoscaling.TargetAnnotationKey, "1982.4"),
-			withMetric(autoscalingv2.MetricSpec{
-				Type: autoscalingv2.ResourceMetricSourceType,
-				Resource: &autoscalingv2.ResourceMetricSource{
+			withMetric(autoscalingv2beta2.MetricSpec{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
 					Name: corev1.ResourceCPU,
-					Target: autoscalingv2.MetricTarget{
-						Type:               autoscalingv2.UtilizationMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:               autoscalingv2beta2.UtilizationMetricType,
 						AverageUtilization: ptr.Int32(1983),
 					},
 				},
@@ -113,21 +113,21 @@ func TestMakeHPA(t *testing.T) {
 			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.CPU),
 			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
 			withAnnotationValue(autoscaling.WindowAnnotationKey, "60s"),
-			withMetric(autoscalingv2.MetricSpec{
-				Type: autoscalingv2.ResourceMetricSourceType,
-				Resource: &autoscalingv2.ResourceMetricSource{
+			withMetric(autoscalingv2beta2.MetricSpec{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
 					Name: corev1.ResourceCPU,
-					Target: autoscalingv2.MetricTarget{
-						Type:               autoscalingv2.UtilizationMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:               autoscalingv2beta2.UtilizationMetricType,
 						AverageUtilization: ptr.Int32(50),
 					},
 				},
 			}),
-			withBehavior(&autoscalingv2.HorizontalPodAutoscalerBehavior{
-				ScaleDown: &autoscalingv2.HPAScalingRules{
+			withBehavior(&autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
+				ScaleDown: &autoscalingv2beta2.HPAScalingRules{
 					StabilizationWindowSeconds: ptr.Int32(60),
 				},
-				ScaleUp: &autoscalingv2.HPAScalingRules{
+				ScaleUp: &autoscalingv2beta2.HPAScalingRules{
 					StabilizationWindowSeconds: ptr.Int32(60),
 				},
 			}),
@@ -138,14 +138,14 @@ func TestMakeHPA(t *testing.T) {
 		want: hpa(
 			withAnnotationValue(autoscaling.MetricAnnotationKey, "customMetric"),
 			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
-			withMetric(autoscalingv2.MetricSpec{
-				Type: autoscalingv2.PodsMetricSourceType,
-				Pods: &autoscalingv2.PodsMetricSource{
-					Metric: autoscalingv2.MetricIdentifier{
+			withMetric(autoscalingv2beta2.MetricSpec{
+				Type: autoscalingv2beta2.PodsMetricSourceType,
+				Pods: &autoscalingv2beta2.PodsMetricSource{
+					Metric: autoscalingv2beta2.MetricIdentifier{
 						Name: "customMetric",
 					},
-					Target: autoscalingv2.MetricTarget{
-						Type:         autoscalingv2.AverageValueMetricType,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:         autoscalingv2beta2.AverageValueMetricType,
 						AverageValue: resource.NewQuantity(50, resource.DecimalSI),
 					},
 				},
@@ -192,8 +192,8 @@ func pa(options ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {
 	return p
 }
 
-func hpa(options ...hpaOption) *autoscalingv2.HorizontalPodAutoscaler {
-	h := &autoscalingv2.HorizontalPodAutoscaler{
+func hpa(options ...hpaOption) *autoscalingv2beta2.HorizontalPodAutoscaler {
+	h := &autoscalingv2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -209,9 +209,9 @@ func hpa(options ...hpaOption) *autoscalingv2.HorizontalPodAutoscaler {
 				BlockOwnerDeletion: ptr.Bool(true),
 			}},
 		},
-		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
 			MaxReplicas: math.MaxInt32,
-			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+			ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
 				APIVersion: "apps",
 				Kind:       "Deployment",
 				Name:       "some-name",
@@ -225,10 +225,10 @@ func hpa(options ...hpaOption) *autoscalingv2.HorizontalPodAutoscaler {
 	return h
 }
 
-type hpaOption func(*autoscalingv2.HorizontalPodAutoscaler)
+type hpaOption func(*autoscalingv2beta2.HorizontalPodAutoscaler)
 
 func withAnnotationValue(key, value string) hpaOption {
-	return func(pa *autoscalingv2.HorizontalPodAutoscaler) {
+	return func(pa *autoscalingv2beta2.HorizontalPodAutoscaler) {
 		if pa.Annotations == nil {
 			pa.Annotations = make(map[string]string, 1)
 		}
@@ -237,25 +237,25 @@ func withAnnotationValue(key, value string) hpaOption {
 }
 
 func withMinReplicas(i int) hpaOption {
-	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+	return func(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
 		hpa.Spec.MinReplicas = ptr.Int32(int32(i))
 	}
 }
 
 func withMaxReplicas(i int) hpaOption {
-	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+	return func(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
 		hpa.Spec.MaxReplicas = int32(i)
 	}
 }
 
-func withMetric(m autoscalingv2.MetricSpec) hpaOption {
-	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
-		hpa.Spec.Metrics = []autoscalingv2.MetricSpec{m}
+func withMetric(m autoscalingv2beta2.MetricSpec) hpaOption {
+	return func(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
+		hpa.Spec.Metrics = []autoscalingv2beta2.MetricSpec{m}
 	}
 }
 
-func withBehavior(m *autoscalingv2.HorizontalPodAutoscalerBehavior) hpaOption {
-	return func(hpa *autoscalingv2.HorizontalPodAutoscaler) {
+func withBehavior(m *autoscalingv2beta2.HorizontalPodAutoscalerBehavior) hpaOption {
+	return func(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) {
 		hpa.Spec.Behavior = m
 	}
 }

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -18,12 +18,12 @@ package v1
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
-	autoscalingv2listers "k8s.io/client-go/listers/autoscaling/v2"
+	autoscalingv2beta2listers "k8s.io/client-go/listers/autoscaling/v2beta2"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	cachingv1alpha1 "knative.dev/caching/pkg/apis/caching/v1alpha1"
@@ -43,7 +43,7 @@ import (
 )
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
-	autoscalingv2.AddToScheme,
+	autoscalingv2beta2.AddToScheme,
 	fakecachingclientset.AddToScheme,
 	fakekubeclientset.AddToScheme,
 	fakenetworkingclientset.AddToScheme,
@@ -149,8 +149,8 @@ func (l *Listers) GetMetricLister() palisters.MetricLister {
 }
 
 // GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.
-func (l *Listers) GetHorizontalPodAutoscalerLister() autoscalingv2listers.HorizontalPodAutoscalerLister {
-	return autoscalingv2listers.NewHorizontalPodAutoscalerLister(l.IndexerFor(&autoscalingv2.HorizontalPodAutoscaler{}))
+func (l *Listers) GetHorizontalPodAutoscalerLister() autoscalingv2beta2listers.HorizontalPodAutoscalerLister {
+	return autoscalingv2beta2listers.NewHorizontalPodAutoscalerLister(l.IndexerFor(&autoscalingv2beta2.HorizontalPodAutoscaler{}))
 }
 
 // GetIngressLister get lister for Ingress resource.

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -249,7 +249,7 @@ func waitForScaleToOne(t *testing.T, deploymentName string, clients *test.Client
 
 func waitForHPAState(t *testing.T, name, namespace string, clients *test.Clients) error {
 	return wait.PollImmediate(time.Second, 15*time.Minute, func() (bool, error) {
-		hpa, err := clients.KubeClient.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		hpa, err := clients.KubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/vendor/knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/fake/fake.go
+++ b/vendor/knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/fake/fake.go
@@ -21,7 +21,7 @@ package fake
 import (
 	context "context"
 
-	horizontalpodautoscaler "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2/horizontalpodautoscaler"
+	horizontalpodautoscaler "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler"
 	fake "knative.dev/pkg/client/injection/kube/informers/factory/fake"
 	controller "knative.dev/pkg/controller"
 	injection "knative.dev/pkg/injection"
@@ -35,6 +35,6 @@ func init() {
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 	f := fake.Get(ctx)
-	inf := f.Autoscaling().V2().HorizontalPodAutoscalers()
+	inf := f.Autoscaling().V2beta2().HorizontalPodAutoscalers()
 	return context.WithValue(ctx, horizontalpodautoscaler.Key{}, inf), inf.Informer()
 }

--- a/vendor/knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/horizontalpodautoscaler.go
+++ b/vendor/knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/horizontalpodautoscaler.go
@@ -21,12 +21,12 @@ package horizontalpodautoscaler
 import (
 	context "context"
 
-	apiautoscalingv2 "k8s.io/api/autoscaling/v2"
+	apiautoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
-	v2 "k8s.io/client-go/informers/autoscaling/v2"
+	v2beta2 "k8s.io/client-go/informers/autoscaling/v2beta2"
 	kubernetes "k8s.io/client-go/kubernetes"
-	autoscalingv2 "k8s.io/client-go/listers/autoscaling/v2"
+	autoscalingv2beta2 "k8s.io/client-go/listers/autoscaling/v2beta2"
 	cache "k8s.io/client-go/tools/cache"
 	client "knative.dev/pkg/client/injection/kube/client"
 	factory "knative.dev/pkg/client/injection/kube/informers/factory"
@@ -45,7 +45,7 @@ type Key struct{}
 
 func withInformer(ctx context.Context) (context.Context, controller.Informer) {
 	f := factory.Get(ctx)
-	inf := f.Autoscaling().V2().HorizontalPodAutoscalers()
+	inf := f.Autoscaling().V2beta2().HorizontalPodAutoscalers()
 	return context.WithValue(ctx, Key{}, inf), inf.Informer()
 }
 
@@ -55,13 +55,13 @@ func withDynamicInformer(ctx context.Context) context.Context {
 }
 
 // Get extracts the typed informer from the context.
-func Get(ctx context.Context) v2.HorizontalPodAutoscalerInformer {
+func Get(ctx context.Context) v2beta2.HorizontalPodAutoscalerInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panic(
-			"Unable to fetch k8s.io/client-go/informers/autoscaling/v2.HorizontalPodAutoscalerInformer from context.")
+			"Unable to fetch k8s.io/client-go/informers/autoscaling/v2beta2.HorizontalPodAutoscalerInformer from context.")
 	}
-	return untyped.(v2.HorizontalPodAutoscalerInformer)
+	return untyped.(v2beta2.HorizontalPodAutoscalerInformer)
 }
 
 type wrapper struct {
@@ -72,18 +72,18 @@ type wrapper struct {
 	resourceVersion string
 }
 
-var _ v2.HorizontalPodAutoscalerInformer = (*wrapper)(nil)
-var _ autoscalingv2.HorizontalPodAutoscalerLister = (*wrapper)(nil)
+var _ v2beta2.HorizontalPodAutoscalerInformer = (*wrapper)(nil)
+var _ autoscalingv2beta2.HorizontalPodAutoscalerLister = (*wrapper)(nil)
 
 func (w *wrapper) Informer() cache.SharedIndexInformer {
-	return cache.NewSharedIndexInformer(nil, &apiautoscalingv2.HorizontalPodAutoscaler{}, 0, nil)
+	return cache.NewSharedIndexInformer(nil, &apiautoscalingv2beta2.HorizontalPodAutoscaler{}, 0, nil)
 }
 
-func (w *wrapper) Lister() autoscalingv2.HorizontalPodAutoscalerLister {
+func (w *wrapper) Lister() autoscalingv2beta2.HorizontalPodAutoscalerLister {
 	return w
 }
 
-func (w *wrapper) HorizontalPodAutoscalers(namespace string) autoscalingv2.HorizontalPodAutoscalerNamespaceLister {
+func (w *wrapper) HorizontalPodAutoscalers(namespace string) autoscalingv2beta2.HorizontalPodAutoscalerNamespaceLister {
 	return &wrapper{client: w.client, namespace: namespace, resourceVersion: w.resourceVersion}
 }
 
@@ -95,8 +95,8 @@ func (w *wrapper) SetResourceVersion(resourceVersion string) {
 	w.resourceVersion = resourceVersion
 }
 
-func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv2.HorizontalPodAutoscaler, err error) {
-	lo, err := w.client.AutoscalingV2().HorizontalPodAutoscalers(w.namespace).List(context.TODO(), v1.ListOptions{
+func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv2beta2.HorizontalPodAutoscaler, err error) {
+	lo, err := w.client.AutoscalingV2beta2().HorizontalPodAutoscalers(w.namespace).List(context.TODO(), v1.ListOptions{
 		LabelSelector:   selector.String(),
 		ResourceVersion: w.resourceVersion,
 	})
@@ -109,8 +109,8 @@ func (w *wrapper) List(selector labels.Selector) (ret []*apiautoscalingv2.Horizo
 	return ret, nil
 }
 
-func (w *wrapper) Get(name string) (*apiautoscalingv2.HorizontalPodAutoscaler, error) {
-	return w.client.AutoscalingV2().HorizontalPodAutoscalers(w.namespace).Get(context.TODO(), name, v1.GetOptions{
+func (w *wrapper) Get(name string) (*apiautoscalingv2beta2.HorizontalPodAutoscaler, error) {
+	return w.client.AutoscalingV2beta2().HorizontalPodAutoscalers(w.namespace).Get(context.TODO(), name, v1.GetOptions{
 		ResourceVersion: w.resourceVersion,
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1302,8 +1302,8 @@ knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/mutatin
 knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/validatingwebhookconfiguration
 knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment
 knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake
-knative.dev/pkg/client/injection/kube/informers/autoscaling/v2/horizontalpodautoscaler
-knative.dev/pkg/client/injection/kube/informers/autoscaling/v2/horizontalpodautoscaler/fake
+knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler
+knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta2/horizontalpodautoscaler/fake
 knative.dev/pkg/client/injection/kube/informers/coordination/v1/lease
 knative.dev/pkg/client/injection/kube/informers/coordination/v1/lease/fake
 knative.dev/pkg/client/injection/kube/informers/core/v1/configmap


### PR DESCRIPTION
This patch runs:
```
$ git revert 974d19d03644dff46b097a15efb4d3d7167765ad
```
as `openshift/release/update-to-head.sh` is not executed for release branch.

/cc @skonto 